### PR TITLE
Resources: New palettes of Guangzhou

### DIFF
--- a/public/resources/palettes/guangzhou.json
+++ b/public/resources/palettes/guangzhou.json
@@ -22,7 +22,7 @@
     {
         "id": "gz3",
         "colour": "#ECA154",
-        "fg": "#000",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Guangzhou on behalf of EnglishRyan.
This should fix #367

> @railmapgen/rmg-palette-resources@0.6.21 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#F3D03E}{\textcolor{#000}{Line 1}}$
$\colorbox{#00629B}{\textcolor{#fff}{Line 2}}$
$\colorbox{#ECA154}{\textcolor{#fff}{Line 3}}$
$\colorbox{#00843D}{\textcolor{#fff}{Line 4}}$
$\colorbox{#C5003E}{\textcolor{#fff}{Line 5}}$
$\colorbox{#80225F}{\textcolor{#fff}{Line 6}}$
$\colorbox{#97D700}{\textcolor{#000}{Line 7}}$
$\colorbox{#008C95}{\textcolor{#fff}{Line 8}}$
$\colorbox{#71CC98}{\textcolor{#000}{Line 9}}$
$\colorbox{#7D9BC1}{\textcolor{#fff}{Line 10}}$
$\colorbox{#470A68}{\textcolor{#fff}{Line 11}}$
$\colorbox{#59621D}{\textcolor{#fff}{Line 12}}$
$\colorbox{#8E8C13}{\textcolor{#fff}{Line 13}}$
$\colorbox{#81312F}{\textcolor{#fff}{Line 14}}$
$\colorbox{#AE8A79}{\textcolor{#fff}{Line 15}}$
$\colorbox{#9E652E}{\textcolor{#fff}{Line 16}}$
$\colorbox{#8B84D7}{\textcolor{#fff}{Line 17}}$
$\colorbox{#0047BA}{\textcolor{#fff}{Line 18}}$
$\colorbox{#BB29BB}{\textcolor{#fff}{Line 19}}$
$\colorbox{#D9027D}{\textcolor{#fff}{Line 20}}$
$\colorbox{#201747}{\textcolor{#fff}{Line 21}}$
$\colorbox{#CD5228}{\textcolor{#fff}{Line 22}}$
$\colorbox{#C4D600}{\textcolor{#000}{Guangfo Line}}$
$\colorbox{#00B5E2}{\textcolor{#fff}{APM Line}}$
$\colorbox{#43B02A}{\textcolor{#fff}{Haizhu Tram Line 1}}$
$\colorbox{#D42D1B}{\textcolor{#fff}{Huangpu Tram Line 1}}$