### PR TITLE
Resources: New palettes of Guiyang

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -312,6 +312,14 @@
         }
     },
     {
+        "id": "guiyang",
+        "country": "CN",
+        "name": {
+            "zh-Hans": "贵阳",
+            "en": "Guiyang"
+        }
+    },
+    {
         "id": "hamburg",
         "country": "DE",
         "name": {

--- a/public/resources/palettes/guiyang.json
+++ b/public/resources/palettes/guiyang.json
@@ -1,0 +1,47 @@
+[
+    {
+        "id": "gy1",
+        "colour": "#33cc33",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "1号线",
+            "en": "Line 1"
+        }
+    },
+    {
+        "id": "gy2",
+        "colour": "#0034c7",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "2号线",
+            "en": "Line 2"
+        }
+    },
+    {
+        "id": "gy3",
+        "colour": "#f72121",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "3号线",
+            "en": "Line 3"
+        }
+    },
+    {
+        "id": "gys1",
+        "colour": "#30e5e2",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "S1号线",
+            "en": "Line S1"
+        }
+    },
+    {
+        "id": "gys2",
+        "colour": "#f19149",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "S2号线",
+            "en": "Line S2"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Guiyang on behalf of AceMendeleev.
This should fix #327

> @railmapgen/rmg-palette-resources@0.6.22 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#33cc33}{\textcolor{#fff}{Line 1}}$
$\colorbox{#0034c7}{\textcolor{#fff}{Line 2}}$
$\colorbox{#f72121}{\textcolor{#fff}{Line 3}}$
$\colorbox{#30e5e2}{\textcolor{#fff}{Line S1}}$
$\colorbox{#f19149}{\textcolor{#fff}{Line S2}}$