### PR TITLE
Resources: New palettes of shijiazhuang

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -792,6 +792,14 @@
         }
     },
     {
+        "id": "shijiazhuang",
+        "country": "CN",
+        "name": {
+            "zh": "石家庄",
+            "en": "shijiazhuang"
+        }
+    },
+    {
         "id": "singapore",
         "country": "SG",
         "name": {

--- a/public/resources/palettes/shijiazhuang.json
+++ b/public/resources/palettes/shijiazhuang.json
@@ -1,0 +1,83 @@
+[
+    {
+        "id": "sjz1",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line1",
+            "zh": "1号线"
+        }
+    },
+    {
+        "id": "sjz2",
+        "colour": "#ffff00",
+        "fg": "#fff",
+        "name": {
+            "en": "Line2",
+            "zh": "2号线"
+        }
+    },
+    {
+        "id": "sjz3",
+        "colour": "#5dcef4",
+        "fg": "#fff",
+        "name": {
+            "en": "Line3",
+            "zh": "3号线"
+        }
+    },
+    {
+        "id": "sjz4",
+        "colour": "#c0c0c0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line4",
+            "zh": "4号线"
+        }
+    },
+    {
+        "id": "sjz5",
+        "colour": "#ff9900",
+        "fg": "#fff",
+        "name": {
+            "en": "Line5",
+            "zh": "5号线"
+        }
+    },
+    {
+        "id": "sjz6",
+        "colour": "#0846aa",
+        "fg": "#fff",
+        "name": {
+            "en": "Line6",
+            "zh": "6号线"
+        }
+    },
+    {
+        "id": "sjz7",
+        "colour": "#8de29e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line7",
+            "zh": "7号线"
+        }
+    },
+    {
+        "id": "sjz8",
+        "colour": "#0011ff",
+        "fg": "#fff",
+        "name": {
+            "en": "Line8",
+            "zh": "8号线"
+        }
+    },
+    {
+        "id": "sjz9",
+        "colour": "#9dd747",
+        "fg": "#fff",
+        "name": {
+            "en": "Line9",
+            "zh": "9号线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of shijiazhuang on behalf of nmwdzs.
This should fix #374

> @railmapgen/rmg-palette-resources@0.6.23 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#ff0000}{\textcolor{#fff}{Line1}}$
$\colorbox{#ffff00}{\textcolor{#fff}{Line2}}$
$\colorbox{#5dcef4}{\textcolor{#fff}{Line3}}$
$\colorbox{#c0c0c0}{\textcolor{#fff}{Line4}}$
$\colorbox{#ff9900}{\textcolor{#fff}{Line5}}$
$\colorbox{#0846aa}{\textcolor{#fff}{Line6}}$
$\colorbox{#8de29e}{\textcolor{#fff}{Line7}}$
$\colorbox{#0011ff}{\textcolor{#fff}{Line8}}$
$\colorbox{#9dd747}{\textcolor{#fff}{Line9}}$