### PR TITLE
Resources: New palettes of Nanning

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -578,6 +578,15 @@
         }
     },
     {
+        "id": "nanning",
+        "country": "CN",
+        "name": {
+            "en": "Nanning",
+            "zh-Hans": "南宁",
+            "zh-Hant": "南寧"
+        }
+    },
+    {
         "id": "naples",
         "country": "IT",
         "name": {

--- a/public/resources/palettes/nanning.json
+++ b/public/resources/palettes/nanning.json
@@ -1,0 +1,74 @@
+[
+    {
+        "id": "nn1",
+        "colour": "#62bd6b",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh": "1号线"
+        }
+    },
+    {
+        "id": "nn2",
+        "colour": "#ee3d2d",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh": "2号线"
+        }
+    },
+    {
+        "id": "nn3",
+        "colour": "#a81ba7",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh": "3号线"
+        }
+    },
+    {
+        "id": "nn4",
+        "colour": "#cdd718",
+        "fg": "#000",
+        "name": {
+            "en": "Line 4",
+            "zh": "4号线"
+        }
+    },
+    {
+        "id": "nn5",
+        "colour": "#3a61a8",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "zh": "5号线"
+        }
+    },
+    {
+        "id": "nn7",
+        "colour": "#e97c17",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh": "6号线"
+        }
+    },
+    {
+        "id": "nn7",
+        "colour": "#ac6a4f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 7",
+            "zh": "7号线"
+        }
+    },
+    {
+        "id": "nn8",
+        "colour": "#1fc4c8",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh": "8号线"
+        }
+    }
+]

--- a/public/resources/palettes/nanning.json
+++ b/public/resources/palettes/nanning.json
@@ -43,32 +43,5 @@
             "en": "Line 5",
             "zh": "5号线"
         }
-    },
-    {
-        "id": "nn7",
-        "colour": "#e97c17",
-        "fg": "#fff",
-        "name": {
-            "en": "Line 6",
-            "zh": "6号线"
-        }
-    },
-    {
-        "id": "nn7",
-        "colour": "#ac6a4f",
-        "fg": "#fff",
-        "name": {
-            "en": "Line 7",
-            "zh": "7号线"
-        }
-    },
-    {
-        "id": "nn8",
-        "colour": "#1fc4c8",
-        "fg": "#fff",
-        "name": {
-            "en": "Line 8",
-            "zh": "8号线"
-        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanning on behalf of NNTR.
This should fix #378

> @railmapgen/rmg-palette-resources@0.6.23 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#62bd6b}{\textcolor{#fff}{Line 1}}$
$\colorbox{#ee3d2d}{\textcolor{#fff}{Line 2}}$
$\colorbox{#a81ba7}{\textcolor{#fff}{Line 3}}$
$\colorbox{#cdd718}{\textcolor{#000}{Line 4}}$
$\colorbox{#3a61a8}{\textcolor{#fff}{Line 5}}$
$\colorbox{#e97c17}{\textcolor{#fff}{Line 6}}$
$\colorbox{#ac6a4f}{\textcolor{#fff}{Line 7}}$
$\colorbox{#1fc4c8}{\textcolor{#fff}{Line 8}}$