### PR TITLE
Resources: New palettes of Shenzhen

### DIFF
--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -180,13 +180,23 @@
         }
     },
     {
-        "id": "szT",
+        "id": "tram",
         "colour": "#b8b8b8",
         "fg": "#fff",
         "name": {
             "en": "Tram",
             "zh-Hans": "有轨电车",
             "zh-Hant": "有軌電車"
+        }
+    },
+    {
+        "id": "sz8orig",
+        "colour": "#E45DBF",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8 (Original)",
+            "zh-Hans": "8号线（原）",
+            "zh-Hant": "8號線（原）"
         }
     }
 ]

--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -1,164 +1,192 @@
 [
     {
         "id": "sz1",
+        "colour": "#00B140",
+        "fg": "#fff",
         "name": {
             "en": "Line 1 (Luobao Line)",
             "zh-Hans": "1号线（罗宝线）",
             "zh-Hant": "1號線（羅寶線）"
-        },
-        "colour": "#00B140"
+        }
     },
     {
         "id": "sz2",
+        "colour": "#B94700",
+        "fg": "#fff",
         "name": {
             "en": "Line 2 (Shekou Line)",
             "zh-Hans": "2号线（蛇口线）",
             "zh-Hant": "2號線（蛇口線）"
-        },
-        "colour": "#B94700"
+        }
     },
     {
         "id": "sz3",
+        "colour": "#00A9E0",
+        "fg": "#fff",
         "name": {
             "en": "Line 3 (Longgang Line)",
             "zh-Hans": "3号线（龙岗线）",
             "zh-Hant": "3號線（龍崗線）"
-        },
-        "colour": "#00A9E0"
+        }
     },
     {
         "id": "sz4",
+        "colour": "#DA291C",
+        "fg": "#fff",
         "name": {
             "en": "Line 4 (Longhua Line)",
             "zh-Hans": "4号线（龙华线）",
             "zh-Hant": "4號線（龍華線）"
-        },
-        "colour": "#DA291C"
+        }
     },
     {
         "id": "sz5",
+        "colour": "#A05EB5",
+        "fg": "#fff",
         "name": {
             "en": "Line 5 (Huanzhong Line)",
             "zh-Hans": "5号线（环中线）",
             "zh-Hant": "5號線（環中線）"
-        },
-        "colour": "#A05EB5"
+        }
     },
     {
         "id": "sz6",
+        "colour": "#00C7B1",
+        "fg": "#fff",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
             "zh-Hant": "6號線"
-        },
-        "colour": "#00C7B1"
+        }
     },
     {
         "id": "sz6b",
+        "colour": "#168773",
+        "fg": "#fff",
         "name": {
             "en": "Line 6 branch",
             "zh-Hans": "6号线支线",
             "zh-Hant": "6號線支線"
-        },
-        "colour": "#168773"
+        }
     },
     {
         "id": "sz7",
+        "colour": "#0033A0",
+        "fg": "#fff",
         "name": {
             "en": "Line 7",
             "zh-Hans": "7号线",
             "zh-Hant": "7號線"
-        },
-        "colour": "#0033A0"
+        }
     },
     {
         "id": "sz8",
+        "colour": "#b94700",
+        "fg": "#fff",
         "name": {
             "en": "Line 8",
             "zh-Hans": "8号线",
             "zh-Hant": "8號線"
-        },
-        "colour": "#E45DBF"
+        }
     },
     {
         "id": "sz9",
+        "colour": "#7B6469",
+        "fg": "#fff",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
             "zh-Hant": "9號線"
-        },
-        "colour": "#7B6469"
+        }
     },
     {
         "id": "sz10",
+        "colour": "#F8779E",
+        "fg": "#fff",
         "name": {
             "en": "Line 10",
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
-        },
-        "colour": "#F8779E"
+        }
     },
     {
         "id": "sz11",
+        "colour": "#672146",
+        "fg": "#fff",
         "name": {
             "en": "Line 11",
             "zh-Hans": "11号线",
             "zh-Hant": "11號線"
-        },
-        "colour": "#672146"
+        }
     },
     {
         "id": "sz12",
+        "colour": "#A192B2",
+        "fg": "#fff",
         "name": {
             "en": "Line 12",
             "zh-Hans": "12号线",
             "zh-Hant": "12號線"
-        },
-        "colour": "#A192B2"
+        }
     },
     {
         "id": "sz13",
+        "colour": "#DE7C00",
+        "fg": "#fff",
         "name": {
             "en": "Line 13",
             "zh-Hans": "13号线",
             "zh-Hant": "13號線"
-        },
-        "colour": "#DE7C00"
+        }
     },
     {
         "id": "sz14",
+        "colour": "#F2C75C",
+        "fg": "#fff",
         "name": {
             "en": "Line 14",
             "zh-Hans": "14号线",
             "zh-Hant": "14號線"
-        },
-        "colour": "#F2C75C"
+        }
     },
     {
         "id": "sz15",
+        "colour": "#84BD00",
+        "fg": "#fff",
         "name": {
             "en": "Line 15",
             "zh-Hans": "15号线",
             "zh-Hant": "15號線"
-        },
-        "colour": "#84BD00"
+        }
     },
     {
         "id": "sz16",
+        "colour": "#1E22AA",
+        "fg": "#fff",
         "name": {
             "en": "Line 16",
             "zh-Hans": "16号线",
             "zh-Hant": "16號線"
-        },
-        "colour": "#1E22AA"
+        }
     },
     {
         "id": "sz20",
+        "colour": "#88DBDF",
+        "fg": "#fff",
         "name": {
             "en": "Line 20",
             "zh-Hans": "20号线",
             "zh-Hant": "20號線"
-        },
-        "colour": "#88DBDF"
+        }
+    },
+    {
+        "id": "szT",
+        "colour": "#b8b8b8",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram",
+            "zh-Hans": "有轨电车",
+            "zh-Hant": "有軌電車"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenzhen on behalf of NNTR.
This should fix #385

> @railmapgen/rmg-palette-resources@0.6.23 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#00B140}{\textcolor{#fff}{Line 1 (Luobao Line)}}$
$\colorbox{#B94700}{\textcolor{#fff}{Line 2 (Shekou Line)}}$
$\colorbox{#00A9E0}{\textcolor{#fff}{Line 3 (Longgang Line)}}$
$\colorbox{#DA291C}{\textcolor{#fff}{Line 4 (Longhua Line)}}$
$\colorbox{#A05EB5}{\textcolor{#fff}{Line 5 (Huanzhong Line)}}$
$\colorbox{#00C7B1}{\textcolor{#fff}{Line 6}}$
$\colorbox{#168773}{\textcolor{#fff}{Line 6 branch}}$
$\colorbox{#0033A0}{\textcolor{#fff}{Line 7}}$
$\colorbox{#b94700}{\textcolor{#fff}{Line 8}}$
$\colorbox{#7B6469}{\textcolor{#fff}{Line 9}}$
$\colorbox{#F8779E}{\textcolor{#fff}{Line 10}}$
$\colorbox{#672146}{\textcolor{#fff}{Line 11}}$
$\colorbox{#A192B2}{\textcolor{#fff}{Line 12}}$
$\colorbox{#DE7C00}{\textcolor{#fff}{Line 13}}$
$\colorbox{#F2C75C}{\textcolor{#fff}{Line 14}}$
$\colorbox{#84BD00}{\textcolor{#fff}{Line 15}}$
$\colorbox{#1E22AA}{\textcolor{#fff}{Line 16}}$
$\colorbox{#88DBDF}{\textcolor{#fff}{Line 20}}$
$\colorbox{#b8b8b8}{\textcolor{#fff}{Tram}}$