### PR TITLE
New palette for Gdańsk

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -265,6 +265,15 @@
         }
     },
     {
+        "id": "gdansk",
+        "country": "PL",
+        "name": {
+            "pl": "Gdańsk",
+            "en": "Gdańsk",
+            "zh": "格但斯克"
+        }
+    },
+    {
         "id": "glasgow",
         "country": "GBSCT",
         "name": {

--- a/public/resources/palettes/gdansk.json
+++ b/public/resources/palettes/gdansk.json
@@ -1,0 +1,82 @@
+[
+    {
+        "id": "tram2",
+        "colour": "#a4ff63",
+        "fg": "#fff",
+        "name": {
+            "en": "2"
+        }
+    },
+    {
+        "id": "tram3",
+        "colour": "#ff00ff",
+        "fg": "#fff",
+        "name": {
+            "en": "3"
+        }
+    },
+    {
+        "id": "tram4",
+        "colour": "#8000db",
+        "fg": "#fff",
+        "name": {
+            "en": "4"
+        }
+    },
+    {
+        "id": "tram5",
+        "colour": "#ffbb54",
+        "fg": "#000",
+        "name": {
+            "en": "5"
+        }
+    },
+    {
+        "id": "tram6",
+        "colour": "#00a1d6",
+        "fg": "#fff",
+        "name": {
+            "en": "6"
+        }
+    },
+    {
+        "id": "tram7",
+        "colour": "#b06700",
+        "fg": "#fff",
+        "name": {
+            "en": "7"
+        }
+    },
+    {
+        "id": "tram8",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "8"
+        }
+    },
+    {
+        "id": "tram9",
+        "colour": "#0044ff",
+        "fg": "#fff",
+        "name": {
+            "en": "9"
+        }
+    },
+    {
+        "id": "tram10",
+        "colour": "#3d2400",
+        "fg": "#fff",
+        "name": {
+            "en": "10"
+        }
+    },
+    {
+        "id": "tram12",
+        "colour": "#ff8521",
+        "fg": "#fff",
+        "name": {
+            "en": "12"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating New palette for Gdańsk - Poland (Tram) on behalf of THIAS18.
This should fix #388

> @railmapgen/rmg-palette-resources@0.6.23 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#a4ff63}{\textcolor{#fff}{2}}$
$\colorbox{#ff00ff}{\textcolor{#fff}{3}}$
$\colorbox{#8000db}{\textcolor{#fff}{4}}$
$\colorbox{#ffbb54}{\textcolor{#000}{5}}$
$\colorbox{#00a1d6}{\textcolor{#fff}{6}}$
$\colorbox{#b06700}{\textcolor{#fff}{7}}$
$\colorbox{#ff0000}{\textcolor{#fff}{8}}$
$\colorbox{#0044ff}{\textcolor{#fff}{9}}$
$\colorbox{#3d2400}{\textcolor{#fff}{10}}$
$\colorbox{#ff8521}{\textcolor{#fff}{12}}$