### PR TITLE
Resources: New palettes of Tokyo (Greater Tokyo Area)

### DIFF
--- a/public/resources/palettes/tokyo.json
+++ b/public/resources/palettes/tokyo.json
@@ -1,669 +1,805 @@
 [
     {
         "id": "g",
+        "colour": "#ff9500",
+        "fg": "#fff",
         "name": {
             "en": "Ginza Line (G)",
             "ja": "銀座線",
             "zh-Hans": "银座线",
             "zh-Hant": "銀座線"
-        },
-        "colour": "#ff9500"
+        }
     },
     {
         "id": "m",
+        "colour": "#f62e36",
+        "fg": "#fff",
         "name": {
             "en": "Marunouchi Line (M)",
             "ja": "丸ノ内線",
             "zh-Hans": "丸之内线",
             "zh-Hant": "丸之內線"
-        },
-        "colour": "#f62e36"
+        }
     },
     {
         "id": "h",
+        "colour": "#b5b5ac",
+        "fg": "#fff",
         "name": {
             "en": "Hibiya Line (H)",
             "ja": "日比谷線",
             "zh-Hans": "日比谷线",
             "zh-Hant": "日比谷線"
-        },
-        "colour": "#b5b5ac"
+        }
     },
     {
         "id": "t",
+        "colour": "#009bbf",
+        "fg": "#fff",
         "name": {
             "en": "Tōzai Line (T)",
             "ja": "東西線",
             "zh-Hans": "东西线",
             "zh-Hant": "東西線"
-        },
-        "colour": "#009bbf"
+        }
     },
     {
         "id": "c",
+        "colour": "#00bb85",
+        "fg": "#fff",
         "name": {
             "en": "Chiyoda Line (C)",
             "ja": "千代田線",
             "zh-Hans": "千代田线",
             "zh-Hant": "千代田線"
-        },
-        "colour": "#00bb85"
+        }
     },
     {
         "id": "y",
+        "colour": "#c1a470",
+        "fg": "#fff",
         "name": {
             "en": "Yūrakuchō Line (Y)",
             "ja": "有楽町線",
             "zh-Hans": "有乐町线",
             "zh-Hant": "有樂町線"
-        },
-        "colour": "#c1a470"
+        }
     },
     {
         "id": "z",
+        "colour": "#8f76d6",
+        "fg": "#fff",
         "name": {
             "en": "Hanzōmon Line (Z)",
             "ja": "半蔵門線",
             "zh-Hans": "半藏门线",
             "zh-Hant": "半藏門線"
-        },
-        "colour": "#8f76d6"
+        }
     },
     {
         "id": "n",
+        "colour": "#00ac9b",
+        "fg": "#fff",
         "name": {
             "en": "Namboku Line (N)",
             "ja": "南北線",
             "zh-Hans": "南北线",
             "zh-Hant": "南北線"
-        },
-        "colour": "#00ac9b"
+        }
     },
     {
         "id": "f",
+        "colour": "#9c5e31",
+        "fg": "#fff",
         "name": {
             "en": "Fukutoshin Line (F)",
             "ja": "副都心線",
             "zh-Hans": "副都心线",
             "zh-Hant": "副都心線"
-        },
-        "colour": "#9c5e31"
+        }
     },
     {
         "id": "a",
+        "colour": "#ec6e65",
+        "fg": "#fff",
         "name": {
             "en": "Asakusa Line (A)",
             "ja": "浅草線",
             "zh-Hans": "浅草线",
             "zh-Hant": "淺草線"
-        },
-        "colour": "#ec6e65"
+        }
     },
     {
         "id": "i",
+        "colour": "#006ab8",
+        "fg": "#fff",
         "name": {
             "en": "Mita Line (I)",
             "ja": "三田線",
             "zh-Hans": "三田线",
             "zh-Hant": "三田線"
-        },
-        "colour": "#006ab8"
+        }
     },
     {
         "id": "s",
+        "colour": "#b0bf1e",
+        "fg": "#fff",
         "name": {
             "en": "Shinjuku Line (S)",
             "ja": "新宿線",
             "zh-Hans": "新宿线",
             "zh-Hant": "新宿線"
-        },
-        "colour": "#b0bf1e"
+        }
     },
     {
         "id": "o",
+        "colour": "#ce045b",
+        "fg": "#fff",
         "name": {
             "en": "Ōedo Line (O)",
             "ja": "大江戸線",
             "zh-Hans": "大江户线",
             "zh-Hant": "大江戶線"
-        },
-        "colour": "#ce045b"
+        }
     },
     {
         "id": "jy",
+        "colour": "#B1CB39",
+        "fg": "#fff",
         "name": {
             "en": "Yamanote Line (JY)",
             "ja": "山手線",
-            "zh-Hant": "山手線"
-        },
-        "colour": "#B1CB39"
+            "zh-Hant": "山手線",
+            "zh-Hans": "山手线"
+        }
     },
     {
         "id": "jk",
+        "colour": "#1DAED1",
+        "fg": "#fff",
         "name": {
             "en": "Keihin-Tōhoku Line/Negishi Line (JK)",
-            "ja": "京浜東北線・根岸線"
-        },
-        "colour": "#1DAED1"
+            "ja": "京浜東北線・根岸線",
+            "zh-Hant": "京濱東北線・根岸線",
+            "zh-Hans": "京滨东北线・根岸线"
+        }
     },
     {
         "id": "jb",
+        "colour": "#F2D01F",
+        "fg": "#fff",
         "name": {
             "en": "Chūō Line/Sōbu Line (Local) (JB)",
-            "ja": "中央・総武線"
-        },
-        "colour": "#F2D01F"
+            "ja": "中央・総武線",
+            "zh-Hans": "中央・总武线",
+            "zh-Hant": "中央・總武線"
+        }
     },
     {
         "id": "jc",
+        "colour": "#DD6935",
+        "fg": "#fff",
         "name": {
             "en": "Chūō Line (Rapid)/Chūō Line/Ōme Line/Itsukaichi Line (JC)",
-            "ja": "中央線快速・中央本線・青梅線・五日市線"
-        },
-        "colour": "#DD6935"
+            "ja": "中央線快速・中央本線・青梅線・五日市線",
+            "zh-Hans": "中央线快速・中央本线・青梅线・五日市线",
+            "zh-Hant": "中央線快速・中央本線・青梅線・五日市線"
+        }
     },
     {
         "id": "jo",
+        "colour": "#1069B4",
+        "fg": "#fff",
         "name": {
             "en": "Yokosuka Line/Sōbu Line (Rapid)/Sōbu Line/Narita Line (JO)",
-            "ja": "横須賀線・総武快速線・総武本線・成田線"
-        },
-        "colour": "#1069B4"
+            "ja": "横須賀線・総武快速線・総武本線・成田線",
+            "zh-Hans": "横须贺线・总武快速线・总武本线・成田线",
+            "zh-Hant": "橫須賀線・總武快速線・總武本線・成田線"
+        }
     },
     {
         "id": "ju",
+        "colour": "#F18E41",
+        "fg": "#fff",
         "name": {
             "en": "Utsunomiya Line/Takasaki Line (JU)",
-            "ja": "宇都宮線・高崎線"
-        },
-        "colour": "#F18E41"
+            "ja": "宇都宮線・高崎線",
+            "zh-Hans": "宇都宫线・高崎线",
+            "zh-Hant": "宇都宮線・高崎線"
+        }
     },
     {
         "id": "jt",
+        "colour": "#F0862B",
+        "fg": "#fff",
         "name": {
             "en": "Tōkaidō Line/Itō Line (JT)",
-            "ja": "東海道線・伊東線"
-        },
-        "colour": "#F0862B"
+            "ja": "東海道線・伊東線",
+            "zh-Hans": "东海道线・伊东线",
+            "zh-Hant": "東海道線・伊東線"
+        }
     },
     {
         "id": "ja",
+        "colour": "#14A676",
+        "fg": "#fff",
         "name": {
             "en": "Saikyō Line (JA)",
-            "ja": "埼京線"
-        },
-        "colour": "#14A676"
+            "ja": "埼京線",
+            "zh-Hans": "埼京线",
+            "zh-Hant": "埼京線"
+        }
     },
     {
         "id": "js",
+        "colour": "#DB2027",
+        "fg": "#fff",
         "name": {
             "en": "Shōnan-Shinjuku Line (JS)",
             "ja": "湘南新宿ライン",
             "zh-Hans": "湘南新宿线",
             "zh-Hant": "湘南新宿線"
-        },
-        "colour": "#DB2027"
+        }
     },
     {
         "id": "jj",
+        "colour": "#1DAF7E",
+        "fg": "#fff",
         "name": {
             "en": "Jōban Line (Rapid) (JJ)",
-            "ja": "常磐線快速電車"
-        },
-        "colour": "#1DAF7E"
+            "ja": "常磐線快速電車",
+            "zh-Hans": "常磐线快速电车",
+            "zh-Hant": "常磐線快速電車"
+        }
     },
     {
         "id": "jl",
+        "colour": "#868587",
+        "fg": "#fff",
         "name": {
             "en": "Jōban Line (Local) (JL)",
-            "ja": "常磐線各駅停車"
-        },
-        "colour": "#868587"
+            "ja": "常磐線各駅停車",
+            "zh-Hans": "常磐线各站停车",
+            "zh-Hant": "常磐線各站停車"
+        }
     },
     {
         "id": "je",
+        "colour": "#D01827",
+        "fg": "#fff",
         "name": {
             "en": "Keiyō Line (JE)",
             "ja": "京葉線",
             "zh-Hans": "京叶线",
             "zh-Hant": "京葉線"
-        },
-        "colour": "#D01827"
+        }
     },
     {
         "id": "jh",
+        "colour": "#B1CB39",
+        "fg": "#fff",
         "name": {
             "en": "Yokohama Line (JH)",
-            "ja": "横浜線"
-        },
-        "colour": "#B1CB39"
+            "ja": "横浜線",
+            "zh-Hans": "横滨线",
+            "zh-Hant": "橫濱線"
+        }
     },
     {
         "id": "jm",
+        "colour": "#EB5A28",
+        "fg": "#fff",
         "name": {
             "en": "Musashino Line (JM)",
-            "ja": "武蔵野線"
-        },
-        "colour": "#EB5A28"
+            "ja": "武蔵野線",
+            "zh-Hans": "武藏野线",
+            "zh-Hant": "武藏野線"
+        }
     },
     {
         "id": "jn",
+        "colour": "#F2D01F",
+        "fg": "#fff",
         "name": {
             "en": "Nambu Line (JN)",
             "ja": "南武線",
             "zh-Hans": "南武线",
             "zh-Hant": "南武線"
-        },
-        "colour": "#F2D01F"
+        }
     },
     {
         "id": "ji",
+        "colour": "#F2D01F",
+        "fg": "#fff",
         "name": {
             "en": "Tsurumi Line (JI)",
             "ja": "鶴見線",
             "zh-Hans": "鹤见线",
             "zh-Hant": "鶴見線"
-        },
-        "colour": "#F2D01F"
+        }
     },
     {
         "id": "mo",
+        "colour": "#26326A",
+        "fg": "#fff",
         "name": {
             "en": "Tokyo Monorail Haneda Airport Line (MO)",
             "ja": "東京モノレール羽田空港線",
             "zh-Hans": "东京单轨电车羽田机场线",
             "zh-Hant": "東京單軌電車羽田機場線"
-        },
-        "colour": "#26326A"
+        }
     },
     {
         "id": "yb",
+        "colour": "#2F56A5",
+        "fg": "#fff",
         "name": {
             "en": "Yokohama Municipal Subway Blue Line (B)",
-            "ja": "横浜市営地下鉄ブルーライン"
-        },
-        "colour": "#2F56A5"
+            "ja": "横浜市営地下鉄ブルーライン",
+            "zh-Hans": "横滨市营地下铁蓝线",
+            "zh-Hant": "橫濱市營地下鐵藍線"
+        }
     },
     {
         "id": "yg",
+        "colour": "#28846E",
+        "fg": "#fff",
         "name": {
             "en": "Yokohama Municipal Subway Green Line (G)",
-            "ja": "横浜市営地下鉄グリーンライン"
-        },
-        "colour": "#28846E"
+            "ja": "横浜市営地下鉄グリーンライン",
+            "zh-Hans": "横滨市营地下铁绿线",
+            "zh-Hant": "橫濱市營地下鐵綠線"
+        }
     },
     {
         "id": "ty",
+        "colour": "#DA0042",
+        "fg": "#fff",
         "name": {
             "en": "Tōkyū Tōyoko Line (TY)",
-            "ja": "東急東横線"
-        },
-        "colour": "#DA0042"
+            "ja": "東急東横線",
+            "zh-Hans": "东急东横线",
+            "zh-Hant": "東急東橫線"
+        }
     },
     {
         "id": "mg",
+        "colour": "#009CD3",
+        "fg": "#fff",
         "name": {
             "en": "Tōkyū Meguro Line (MG)",
             "ja": "東急目黒線",
             "zh-Hans": "东急目黑线",
             "zh-Hant": "東急目黑線"
-        },
-        "colour": "#009CD3"
+        }
     },
     {
         "id": "dt",
+        "colour": "#00AA8D",
+        "fg": "#fff",
         "name": {
             "en": "Tōkyū Den-en-toshi Line (DT)",
             "ja": "東急田園都市線",
             "zh-Hans": "东急田园都市线",
             "zh-Hant": "東急田園都市線"
-        },
-        "colour": "#00AA8D"
+        }
     },
     {
         "id": "om",
+        "colour": "#F18C43",
+        "fg": "#fff",
         "name": {
             "en": "Tōkyū Ōimachi Line (OM)",
             "ja": "東急大井町線",
             "zh-Hans": "东急大井町线",
             "zh-Hant": "東急大井町線"
-        },
-        "colour": "#F18C43"
+        }
     },
     {
         "id": "ik",
+        "colour": "#EE86A8",
+        "fg": "#fff",
         "name": {
             "en": "Tōkyū Ikegami Line (IK)",
             "ja": "東急池上線",
             "zh-Hans": "东急池上线",
             "zh-Hant": "東急池上線"
-        },
-        "colour": "#EE86A8"
+        }
     },
     {
         "id": "tm",
+        "colour": "#AE0079",
+        "fg": "#fff",
         "name": {
             "en": "Tōkyū Tamagawa Line (TM)",
             "ja": "東急多摩川線",
             "zh-Hans": "东急多摩川线",
             "zh-Hant": "東急多摩川線"
-        },
-        "colour": "#AE0079"
+        }
     },
     {
         "id": "kd",
+        "colour": "#0071BE",
+        "fg": "#fff",
         "name": {
             "en": "Kodomonokuni Line (KD)",
-            "ja": "こどもの国線"
-        },
-        "colour": "#0071BE"
+            "ja": "こどもの国線",
+            "zh-Hans": "子供之国线",
+            "zh-Hant": "子供之國線"
+        }
     },
     {
         "id": "sg",
+        "colour": "#FCC800",
+        "fg": "#fff",
         "name": {
             "en": "Tōkyū Setagaya Line (SG)",
             "ja": "東急世田谷線",
             "zh-Hans": "东急世田谷线",
             "zh-Hant": "東急世田谷線"
-        },
-        "colour": "#FCC800"
+        }
     },
     {
         "id": "si",
+        "colour": "#EF7A00",
+        "fg": "#fff",
         "name": {
             "en": "Seibu Ikebukuro Line (SI)",
             "ja": "西武池袋線",
             "zh-Hans": "西武池袋线",
             "zh-Hant": "西武池袋線"
-        },
-        "colour": "#EF7A00"
+        }
     },
     {
         "id": "ss",
+        "colour": "#00A6BF",
+        "fg": "#fff",
         "name": {
             "en": "Seibu Shinjuku Line (SS)",
             "ja": "西武新宿線",
             "zh-Hans": "西武新宿线",
             "zh-Hant": "西武新宿線"
-        },
-        "colour": "#00A6BF"
+        }
     },
     {
         "id": "sk",
+        "colour": "#38b35c",
+        "fg": "#fff",
         "name": {
             "en": "Seibu Kokubunji Line (SK)",
             "ja": "西武国分寺線",
             "zh-Hans": "西武国分寺线",
             "zh-Hant": "西武國分寺線"
-        },
-        "colour": "#38b35c"
+        }
     },
     {
         "id": "sw",
+        "colour": "#f17c24",
+        "fg": "#fff",
         "name": {
             "en": "Seibu Tamagawa Line (SW)",
             "ja": "西武多摩川線",
             "zh-Hans": "西武多摩川线",
             "zh-Hant": "西武多摩川線"
-        },
-        "colour": "#f17c24"
+        }
     },
     {
         "id": "st",
+        "colour": "#f7aa2c",
+        "fg": "#fff",
         "name": {
             "en": "Seibu Tamako Line (ST)",
-            "ja": "西武多摩湖線"
-        },
-        "colour": "#f7aa2c"
+            "ja": "西武多摩湖線",
+            "zh-Hans": "西武多摩湖线",
+            "zh-Hant": "西武多摩湖線"
+        }
     },
     {
         "id": "sy",
+        "colour": "#ec4840",
+        "fg": "#fff",
         "name": {
             "en": "Seibu Yamaguchi Line (SY)",
-            "ja": "西武山口線"
-        },
-        "colour": "#ec4840"
+            "ja": "西武山口線",
+            "zh-Hans": "西武山口线",
+            "zh-Hant": "西武山口線"
+        }
     },
     {
         "id": "ts",
+        "colour": "#006CBA",
+        "fg": "#fff",
         "name": {
             "en": "Tōbu Skytree Line (TS)",
             "ja": "東武スカイツリーライン",
             "zh-Hans": "东武晴空塔线",
             "zh-Hant": "東武晴空塔線"
-        },
-        "colour": "#006CBA"
+        }
     },
     {
         "id": "ti",
+        "colour": "#E61919",
+        "fg": "#fff",
         "name": {
             "en": "Tōbu Isesaki Line (TI)",
-            "ja": "東武伊勢崎線"
-        },
-        "colour": "#E61919"
+            "ja": "東武伊勢崎線",
+            "zh-Hans": "东武伊势崎线",
+            "zh-Hant": "東武伊勢崎線"
+        }
     },
     {
         "id": "tn",
+        "colour": "#F5A200",
+        "fg": "#fff",
         "name": {
             "en": "Tōbu Nikkō Line (TN)",
-            "ja": "東武日光線"
-        },
-        "colour": "#F5A200"
+            "ja": "東武日光線",
+            "zh-Hans": "东武日光线",
+            "zh-Hant": "東武日光線"
+        }
     },
     {
         "id": "td",
+        "colour": "#40B4E5",
+        "fg": "#fff",
         "name": {
             "en": "Tōbu Urban Park Line (TD)",
-            "ja": "東武アーバンパークライン"
-        },
-        "colour": "#40B4E5"
+            "ja": "東武アーバンパークライン",
+            "zh-Hans": "东武都市公园线",
+            "zh-Hant": "東武都市公園線"
+        }
     },
     {
         "id": "tj",
+        "colour": "#00428E",
+        "fg": "#fff",
         "name": {
             "en": "Tōbu Tōjō Line (TJ)",
             "ja": "東武東上線",
             "zh-Hans": "东武东上线",
             "zh-Hant": "東武東上線"
-        },
-        "colour": "#00428E"
+        }
     },
     {
         "id": "ks",
+        "colour": "#005AAA",
+        "fg": "#fff",
         "name": {
             "en": "Keisei Main Line (KS)",
             "ja": "京成本線",
             "zh-Hans": "京成本线",
             "zh-Hant": "京成本線"
-        },
-        "colour": "#005AAA"
+        }
     },
     {
         "id": "ksnrt",
+        "colour": "#FF8620",
+        "fg": "#fff",
         "name": {
             "en": "Keisei Narita Airport Line (KS)",
-            "ja": "京成成田空港線"
-        },
-        "colour": "#FF8620"
+            "ja": "京成成田空港線",
+            "zh-Hans": "京成成田机场线",
+            "zh-Hant": "京成成田機場線"
+        }
     },
     {
         "id": "sl",
+        "colour": "#EF59A1",
+        "fg": "#fff",
         "name": {
             "en": "Shin-Keisei Line (SL)",
-            "ja": "新京成線"
-        },
-        "colour": "#EF59A1"
+            "ja": "新京成線",
+            "zh-Hans": "新京成线",
+            "zh-Hant": "新京成線"
+        }
     },
     {
         "id": "hs",
+        "colour": "#00bdf2",
+        "fg": "#fff",
         "name": {
             "en": "Hokusō Line (HS)",
             "ja": "北総線",
             "zh-Hans": "北总线",
             "zh-Hant": "北總線"
-        },
-        "colour": "#00bdf2"
+        }
     },
     {
         "id": "sr",
+        "colour": "#00A650",
+        "fg": "#fff",
         "name": {
             "en": "Shibayama Railway Line (SR)",
             "ja": "芝山鉄道線",
             "zh-Hans": "芝山铁道线",
             "zh-Hant": "芝山鐵道線"
-        },
-        "colour": "#00A650"
+        }
     },
     {
         "id": "oh",
+        "colour": "#0085CE",
+        "fg": "#fff",
         "name": {
             "en": "Odakyū Lines (OH/OE/OT)",
             "ja": "小田急線",
             "zh-Hans": "小田急线",
             "zh-Hant": "小田急線"
-        },
-        "colour": "#0085CE"
+        }
     },
     {
         "id": "ko",
+        "colour": "#D5007F",
+        "fg": "#fff",
         "name": {
             "en": "Keiō Line (KO)",
             "ja": "京王線",
             "zh-Hans": "京王线",
             "zh-Hant": "京王線"
-        },
-        "colour": "#D5007F"
+        }
     },
     {
         "id": "in",
+        "colour": "#103675",
+        "fg": "#fff",
         "name": {
             "en": "Keiō Inokashira Line (IN)",
             "ja": "京王井の頭線",
             "zh-Hans": "京王井之头线",
             "zh-Hant": "京王井之頭線"
-        },
-        "colour": "#103675"
+        }
     },
     {
         "id": "kk",
+        "colour": "#00BFFF",
+        "fg": "#fff",
         "name": {
             "en": "Keikyū Main Line (KK)",
-            "ja": "京急本線"
-        },
-        "colour": "#00BFFF"
+            "ja": "京急本線",
+            "zh-Hans": "京急本线",
+            "zh-Hant": "京急本線"
+        }
     },
     {
         "id": "so",
+        "colour": "#0071C1",
+        "fg": "#fff",
         "name": {
             "en": "Sōtetsu Main Line (SO)",
-            "ja": "相鉄本線"
-        },
-        "colour": "#0071C1"
+            "ja": "相鉄本線",
+            "zh-Hans": "相线本线",
+            "zh-Hant": "相鐵本線"
+        }
     },
     {
         "id": "r",
+        "colour": "#00418e",
+        "fg": "#fff",
         "name": {
             "en": "Rinkai Line (R)",
             "ja": "りんかい線",
             "zh-Hans": "临海线",
             "zh-Hant": "臨海線"
-        },
-        "colour": "#00418e"
+        }
     },
     {
         "id": "u",
+        "colour": "#1662B8",
+        "fg": "#fff",
         "name": {
             "en": "New Transit Yurikamome (U)",
             "ja": "新交通ゆりかもめ",
             "zh-Hans": "百合海鸥线",
             "zh-Hant": "百合海鷗線"
-        },
-        "colour": "#1662B8"
+        }
     },
     {
         "id": "sa",
+        "colour": "#d75b80",
+        "fg": "#fff",
         "name": {
             "en": "Tokyo Sakura Tram (SA)",
             "ja": "東京さくらトラム（都電荒川線）",
             "zh-Hans": "东京樱花有轨电车",
             "zh-Hant": "東京櫻花路面電車"
-        },
-        "colour": "#d75b80"
+        }
     },
     {
         "id": "nt",
+        "colour": "#D53A77",
+        "fg": "#fff",
         "name": {
             "en": "Nippori-Toneri Liner (NT)",
             "ja": "日暮里・舎人ライナー",
             "zh-Hans": "日暮里-舍人线",
             "zh-Hant": "日暮里-舍人線"
-        },
-        "colour": "#D53A77"
+        }
     },
     {
         "id": "mm",
+        "colour": "#19559F",
+        "fg": "#fff",
         "name": {
             "en": "Minatomirai Line (MM)",
-            "ja": "みなとみらい線"
-        },
-        "colour": "#19559F"
+            "ja": "みなとみらい線",
+            "zh-Hans": "港未来线",
+            "zh-Hant": "港未來線"
+        }
     },
     {
         "id": "en",
+        "colour": "#f6be18",
+        "fg": "#fff",
         "name": {
             "en": "Enoshima Dentetsu Line (EN)",
-            "ja": "江ノ島電鉄線"
-        },
-        "colour": "#f6be18"
+            "ja": "江ノ島電鉄線",
+            "zh-Hans": "江之岛电铁线",
+            "zh-Hant": "江之島電鐵線"
+        }
     },
     {
         "id": "tr",
+        "colour": "#5AB65C",
+        "fg": "#fff",
         "name": {
             "en": "Tōyō Rapid Railway Line (TR)",
             "ja": "東葉高速線",
             "zh-Hans": "东叶高速线",
             "zh-Hant": "東葉高速線"
-        },
-        "colour": "#5AB65C"
+        }
     },
     {
         "id": "srr",
+        "colour": "#3564AF",
+        "fg": "#fff",
         "name": {
             "en": "Saitama Rapid Railway Line (SR)",
-            "ja": "埼玉高速鉄道線"
-        },
-        "colour": "#3564AF"
+            "ja": "埼玉高速鉄道線",
+            "zh-Hans": "埼玉高速铁道线",
+            "zh-Hant": "埼玉高速鐵道線"
+        }
     },
     {
         "id": "tt",
+        "colour": "#27625E",
+        "fg": "#fff",
         "name": {
             "en": "Tama Toshi Monorail Line",
-            "ja": "多摩都市モノレール線"
-        },
-        "colour": "#27625E"
+            "ja": "多摩都市モノレール線",
+            "zh-Hans": "多摩都市单轨电车线",
+            "zh-Hant": "多摩都市單軌電車線"
+        }
     },
     {
         "id": "ns",
+        "colour": "#18A698",
+        "fg": "#fff",
         "name": {
             "en": "Ina Line (NS)",
-            "ja": "伊奈線"
-        },
-        "colour": "#18A698"
+            "ja": "伊奈線",
+            "zh-Hans": "伊奈线",
+            "zh-Hant": "伊奈線"
+        }
     },
     {
         "id": "cd",
+        "colour": "#a52a2a",
+        "fg": "#fff",
         "name": {
             "en": "Chōshi Electric Railway Line (CD)",
-            "ja": "銚子電気鉄道線"
-        },
-        "colour": "#a52a2a"
+            "ja": "銚子電気鉄道線",
+            "zh-Hans": "铫子电气铁道线",
+            "zh-Hant": "銚子電氣鐵道線"
+        }
     },
     {
         "id": "cm",
+        "colour": "#2843ba",
+        "fg": "#fff",
         "name": {
             "en": "Chiba Urban Monorail (CM)",
-            "ja": "千葉都市モノレール"
-        },
-        "colour": "#2843ba"
+            "ja": "千葉都市モノレール",
+            "zh-Hans": "千叶都市单轨电车",
+            "zh-Hant": "千葉都市單軌電車"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Tokyo (Greater Tokyo Area) on behalf of wongchito.
This should fix #401

> @railmapgen/rmg-palette-resources@0.6.26 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#ff9500}{\textcolor{#fff}{Ginza Line (G)}}$
$\colorbox{#f62e36}{\textcolor{#fff}{Marunouchi Line (M)}}$
$\colorbox{#b5b5ac}{\textcolor{#fff}{Hibiya Line (H)}}$
$\colorbox{#009bbf}{\textcolor{#fff}{Tōzai Line (T)}}$
$\colorbox{#00bb85}{\textcolor{#fff}{Chiyoda Line (C)}}$
$\colorbox{#c1a470}{\textcolor{#fff}{Yūrakuchō Line (Y)}}$
$\colorbox{#8f76d6}{\textcolor{#fff}{Hanzōmon Line (Z)}}$
$\colorbox{#00ac9b}{\textcolor{#fff}{Namboku Line (N)}}$
$\colorbox{#9c5e31}{\textcolor{#fff}{Fukutoshin Line (F)}}$
$\colorbox{#ec6e65}{\textcolor{#fff}{Asakusa Line (A)}}$
$\colorbox{#006ab8}{\textcolor{#fff}{Mita Line (I)}}$
$\colorbox{#b0bf1e}{\textcolor{#fff}{Shinjuku Line (S)}}$
$\colorbox{#ce045b}{\textcolor{#fff}{Ōedo Line (O)}}$
$\colorbox{#B1CB39}{\textcolor{#fff}{Yamanote Line (JY)}}$
$\colorbox{#1DAED1}{\textcolor{#fff}{Keihin-Tōhoku Line/Negishi Line (JK)}}$
$\colorbox{#F2D01F}{\textcolor{#fff}{Chūō Line/Sōbu Line (Local) (JB)}}$
$\colorbox{#DD6935}{\textcolor{#fff}{Chūō Line (Rapid)/Chūō Line/Ōme Line/Itsukaichi Line (JC)}}$
$\colorbox{#1069B4}{\textcolor{#fff}{Yokosuka Line/Sōbu Line (Rapid)/Sōbu Line/Narita Line (JO)}}$
$\colorbox{#F18E41}{\textcolor{#fff}{Utsunomiya Line/Takasaki Line (JU)}}$
$\colorbox{#F0862B}{\textcolor{#fff}{Tōkaidō Line/Itō Line (JT)}}$
$\colorbox{#14A676}{\textcolor{#fff}{Saikyō Line (JA)}}$
$\colorbox{#DB2027}{\textcolor{#fff}{Shōnan-Shinjuku Line (JS)}}$
$\colorbox{#1DAF7E}{\textcolor{#fff}{Jōban Line (Rapid) (JJ)}}$
$\colorbox{#868587}{\textcolor{#fff}{Jōban Line (Local) (JL)}}$
$\colorbox{#D01827}{\textcolor{#fff}{Keiyō Line (JE)}}$
$\colorbox{#B1CB39}{\textcolor{#fff}{Yokohama Line (JH)}}$
$\colorbox{#EB5A28}{\textcolor{#fff}{Musashino Line (JM)}}$
$\colorbox{#F2D01F}{\textcolor{#fff}{Nambu Line (JN)}}$
$\colorbox{#F2D01F}{\textcolor{#fff}{Tsurumi Line (JI)}}$
$\colorbox{#26326A}{\textcolor{#fff}{Tokyo Monorail Haneda Airport Line (MO)}}$
$\colorbox{#2F56A5}{\textcolor{#fff}{Yokohama Municipal Subway Blue Line (B)}}$
$\colorbox{#28846E}{\textcolor{#fff}{Yokohama Municipal Subway Green Line (G)}}$
$\colorbox{#DA0042}{\textcolor{#fff}{Tōkyū Tōyoko Line (TY)}}$
$\colorbox{#009CD3}{\textcolor{#fff}{Tōkyū Meguro Line (MG)}}$
$\colorbox{#00AA8D}{\textcolor{#fff}{Tōkyū Den-en-toshi Line (DT)}}$
$\colorbox{#F18C43}{\textcolor{#fff}{Tōkyū Ōimachi Line (OM)}}$
$\colorbox{#EE86A8}{\textcolor{#fff}{Tōkyū Ikegami Line (IK)}}$
$\colorbox{#AE0079}{\textcolor{#fff}{Tōkyū Tamagawa Line (TM)}}$
$\colorbox{#0071BE}{\textcolor{#fff}{Kodomonokuni Line (KD)}}$
$\colorbox{#FCC800}{\textcolor{#fff}{Tōkyū Setagaya Line (SG)}}$
$\colorbox{#EF7A00}{\textcolor{#fff}{Seibu Ikebukuro Line (SI)}}$
$\colorbox{#00A6BF}{\textcolor{#fff}{Seibu Shinjuku Line (SS)}}$
$\colorbox{#38b35c}{\textcolor{#fff}{Seibu Kokubunji Line (SK)}}$
$\colorbox{#f17c24}{\textcolor{#fff}{Seibu Tamagawa Line (SW)}}$
$\colorbox{#f7aa2c}{\textcolor{#fff}{Seibu Tamako Line (ST)}}$
$\colorbox{#ec4840}{\textcolor{#fff}{Seibu Yamaguchi Line (SY)}}$
$\colorbox{#006CBA}{\textcolor{#fff}{Tōbu Skytree Line (TS)}}$
$\colorbox{#E61919}{\textcolor{#fff}{Tōbu Isesaki Line (TI)}}$
$\colorbox{#F5A200}{\textcolor{#fff}{Tōbu Nikkō Line (TN)}}$
$\colorbox{#40B4E5}{\textcolor{#fff}{Tōbu Urban Park Line (TD)}}$
$\colorbox{#00428E}{\textcolor{#fff}{Tōbu Tōjō Line (TJ)}}$
$\colorbox{#005AAA}{\textcolor{#fff}{Keisei Main Line (KS)}}$
$\colorbox{#FF8620}{\textcolor{#fff}{Keisei Narita Airport Line (KS)}}$
$\colorbox{#EF59A1}{\textcolor{#fff}{Shin-Keisei Line (SL)}}$
$\colorbox{#00bdf2}{\textcolor{#fff}{Hokusō Line (HS)}}$
$\colorbox{#00A650}{\textcolor{#fff}{Shibayama Railway Line (SR)}}$
$\colorbox{#0085CE}{\textcolor{#fff}{Odakyū Lines (OH/OE/OT)}}$
$\colorbox{#D5007F}{\textcolor{#fff}{Keiō Line (KO)}}$
$\colorbox{#103675}{\textcolor{#fff}{Keiō Inokashira Line (IN)}}$
$\colorbox{#00BFFF}{\textcolor{#fff}{Keikyū Main Line (KK)}}$
$\colorbox{#0071C1}{\textcolor{#fff}{Sōtetsu Main Line (SO)}}$
$\colorbox{#00418e}{\textcolor{#fff}{Rinkai Line (R)}}$
$\colorbox{#1662B8}{\textcolor{#fff}{New Transit Yurikamome (U)}}$
$\colorbox{#d75b80}{\textcolor{#fff}{Tokyo Sakura Tram (SA)}}$
$\colorbox{#D53A77}{\textcolor{#fff}{Nippori-Toneri Liner (NT)}}$
$\colorbox{#19559F}{\textcolor{#fff}{Minatomirai Line (MM)}}$
$\colorbox{#f6be18}{\textcolor{#fff}{Enoshima Dentetsu Line (EN)}}$
$\colorbox{#5AB65C}{\textcolor{#fff}{Tōyō Rapid Railway Line (TR)}}$
$\colorbox{#3564AF}{\textcolor{#fff}{Saitama Rapid Railway Line (SR)}}$
$\colorbox{#27625E}{\textcolor{#fff}{Tama Toshi Monorail Line}}$
$\colorbox{#18A698}{\textcolor{#fff}{Ina Line (NS)}}$
$\colorbox{#a52a2a}{\textcolor{#fff}{Chōshi Electric Railway Line (CD)}}$
$\colorbox{#2843ba}{\textcolor{#fff}{Chiba Urban Monorail (CM)}}$