### PR TITLE
Resources: New palettes of Washington DC

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -959,7 +959,8 @@
         "country": "US",
         "name": {
             "en": "Washington DC",
-            "zh": "华盛顿特区"
+            "zh-Hans": "华盛顿特区",
+            "zh-Hant": "華盛頓特區"
         }
     },
     {

--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -955,6 +955,14 @@
         }
     },
     {
+        "id": "washington",
+        "country": "US",
+        "name": {
+            "en": "Washington DC",
+            "zh": "华盛顿特区"
+        }
+    },
+    {
         "id": "wuhan",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/washington.json
+++ b/public/resources/palettes/washington.json
@@ -1,0 +1,62 @@
+[
+    {
+        "id": "wdcr",
+        "colour": "#e31233",
+        "fg": "#fff",
+        "name": {
+            "en": "Red line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線"
+        }
+    },
+    {
+        "id": "wdcb",
+        "colour": "#0077c0",
+        "fg": "#fff",
+        "name": {
+            "en": "Blue line",
+            "zh-Hans": "蓝线",
+            "zh-Hant": "藍線"
+        }
+    },
+    {
+        "id": "wdco",
+        "colour": "#f69318",
+        "fg": "#000",
+        "name": {
+            "en": "Orange line",
+            "zh-Hans": "橙线",
+            "zh-Hant": "橙線"
+        }
+    },
+    {
+        "id": "wdcy",
+        "colour": "#ffd300",
+        "fg": "#000",
+        "name": {
+            "en": "Yellow line",
+            "zh-Hans": "黄线",
+            "zh-Hant": "黃線"
+        }
+    },
+    {
+        "id": "wdcg",
+        "colour": "#00aa4e",
+        "fg": "#fff",
+        "name": {
+            "en": "Green line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線"
+        }
+    },
+    {
+        "id": "wdcs",
+        "colour": "#a2a2a2",
+        "fg": "#000",
+        "name": {
+            "en": " Silver line",
+            "zh-Hans": "银线",
+            "zh-Hant": "銀線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Washington DC on behalf of NNTR.
This should fix #394

> @railmapgen/rmg-palette-resources@0.6.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#e31233}{\textcolor{#fff}{Red line}}$
$\colorbox{#0077c0}{\textcolor{#fff}{Blue line}}$
$\colorbox{#f69318}{\textcolor{#000}{Orange line}}$
$\colorbox{#ffd300}{\textcolor{#000}{Yellow line}}$
$\colorbox{#00aa4e}{\textcolor{#fff}{Green line}}$
$\colorbox{#a2a2a2}{\textcolor{#000}{ Silver line}}$