### PR TITLE
Resources: New palettes of 

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -955,6 +955,15 @@
         }
     },
     {
+        "id": "wenzhou",
+        "country": "CN",
+        "name": {
+            "en": "Wenzhou",
+            "zh-Hans": "温州",
+            "zh-Hant": "溫州"
+        }
+    },
+    {
         "id": "wuhan",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/wenzhou.json
+++ b/public/resources/palettes/wenzhou.json
@@ -1,0 +1,65 @@
+[
+    {
+        "id": "wzs1",
+        "colour": "#2061ad",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh": "S1线"
+        }
+    },
+    {
+        "id": "wzs2",
+        "colour": "#cf3631",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S2",
+            "zh": "S2线"
+        }
+    },
+    {
+        "id": "wzs3",
+        "colour": "#fb7f2c",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S3",
+            "zh": "S3线"
+        }
+    },
+    {
+        "id": "wzm1",
+        "colour": "#6ac1be",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh": "1号线"
+        }
+    },
+    {
+        "id": "wzm2",
+        "colour": "#6ac1be",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh": "2号线"
+        }
+    },
+    {
+        "id": "wzm3",
+        "colour": "#fbc733",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh": "3号线"
+        }
+    },
+    {
+        "id": "wzm4",
+        "colour": "#6ac1be",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "zh": "4号线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of  on behalf of FLYER2048.
This should fix #404

> @railmapgen/rmg-palette-resources@0.6.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#2061ad}{\textcolor{#fff}{Line S1}}$
$\colorbox{#cf3631}{\textcolor{#fff}{Line S2}}$
$\colorbox{#fb7f2c}{\textcolor{#fff}{Line S3}}$
$\colorbox{#6ac1be}{\textcolor{#fff}{Line 1}}$
$\colorbox{#6ac1be}{\textcolor{#fff}{Line 2}}$
$\colorbox{#fbc733}{\textcolor{#fff}{Line 3}}$
$\colorbox{#6ac1be}{\textcolor{#fff}{Line 4}}$