### PR TITLE
Resources: New palettes of San Francisco

### DIFF
--- a/public/resources/palettes/sanfrancisco.json
+++ b/public/resources/palettes/sanfrancisco.json
@@ -1,51 +1,72 @@
 [
     {
         "id": "orange",
+        "colour": "#F9A01B",
+        "fg": "#000",
         "name": {
-            "en": "Richmond–Warm Springs/South Fremont Line"
-        },
-        "colour": "#F9A01B"
+            "en": "Richmond–Warm Springs/South Fremont Line",
+            "zh-Hans": "贝里埃萨/北圣何塞-里奇蒙线",
+            "zh-Hant": "貝里埃薩/北聖何塞-里奇蒙線"
+        }
     },
     {
         "id": "yellow",
+        "colour": "#FFF44E",
+        "fg": "#000",
         "name": {
-            "en": "Antioch–SFO/Millbrae Line"
-        },
-        "colour": "#FFF44E"
+            "en": "Antioch–SFO/Millbrae Line",
+            "zh-Hans": "安条克-旧金山国际机场/密尔布瑞线",
+            "zh-Hant": "安條克-舊金山國際機場/密爾布瑞線"
+        }
     },
     {
         "id": "green",
+        "colour": "#4DB848",
+        "fg": "#000",
         "name": {
-            "en": "Warm Springs/South Fremont–Daly City Line"
-        },
-        "colour": "#4DB848"
+            "en": "Warm Springs/South Fremont–Daly City Line",
+            "zh-Hans": "贝里埃萨/北圣何塞-戴利城线",
+            "zh-Hant": "貝里埃薩/北聖何塞-戴利城線"
+        }
     },
     {
         "id": "red",
+        "colour": "#E21156",
+        "fg": "#fff",
         "name": {
-            "en": "Richmond–Daly City/Millbrae Line"
-        },
-        "colour": "#E21156"
+            "en": "Richmond–Daly City/Millbrae Line",
+            "zh-Hans": "列治文-达利/米尔布雷线",
+            "zh-Hant": "列治文-達利/米爾佈雷線"
+        }
     },
     {
         "id": "blue",
+        "colour": "#00AEEF",
+        "fg": "#fff",
         "name": {
-            "en": "Dublin/Pleasanton–Daly City Line"
-        },
-        "colour": "#00AEEF"
+            "en": "Dublin/Pleasanton–Daly City Line",
+            "zh-Hans": "都柏林/普莱森顿-戴利城线",
+            "zh-Hant": "都柏林/普萊森頓-戴利城線"
+        }
     },
     {
         "id": "shuttle",
+        "colour": "#903E98",
+        "fg": "#fff",
         "name": {
-            "en": "SFO–Millbrae Line"
-        },
-        "colour": "#903E98"
+            "en": "SFO–Millbrae Line",
+            "zh-Hans": "旧金山国际机场-密尔布瑞线",
+            "zh-Hant": "舊金山國際機場-密爾布瑞線"
+        }
     },
     {
         "id": "oak",
+        "colour": "#D4CFA2",
+        "fg": "#fff",
         "name": {
-            "en": "Coliseum–Oakland International Airport Line"
-        },
-        "colour": "#D4CFA2"
+            "en": "Coliseum–Oakland International Airport Line",
+            "zh-Hans": "竞技场-奥克兰国际机场线",
+            "zh-Hant": "競技場-奧克蘭國際機場線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of San Francisco on behalf of Fhooth-YG.
This should fix #406

> @railmapgen/rmg-palette-resources@0.6.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#F9A01B}{\textcolor{#000}{Richmond–Warm Springs/South Fremont Line}}$
$\colorbox{#FFF44E}{\textcolor{#000}{Antioch–SFO/Millbrae Line}}$
$\colorbox{#4DB848}{\textcolor{#000}{Warm Springs/South Fremont–Daly City Line}}$
$\colorbox{#E21156}{\textcolor{#fff}{Richmond–Daly City/Millbrae Line}}$
$\colorbox{#00AEEF}{\textcolor{#fff}{Dublin/Pleasanton–Daly City Line}}$
$\colorbox{#903E98}{\textcolor{#fff}{SFO–Millbrae Line}}$
$\colorbox{#D4CFA2}{\textcolor{#fff}{Coliseum–Oakland International Airport Line}}$