### PR TITLE
Resources: New palettes of GuangNan

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -312,6 +312,14 @@
         }
     },
     {
+        "id": "guangnan",
+        "country": "CN",
+        "name": {
+            "zh-Hans": "广南",
+            "en": "GuangNan"
+        }
+    },
+    {
         "id": "guangzhou",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/guangnan.json
+++ b/public/resources/palettes/guangnan.json
@@ -1,0 +1,56 @@
+[
+    {
+        "id": "gn1",
+        "colour": "#00ff00",
+        "fg": "#000",
+        "name": {
+            "zh-Hans": "1号线",
+            "en": "Line 1"
+        }
+    },
+    {
+        "id": "gn2",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "2号线",
+            "en": "Line 2"
+        }
+    },
+    {
+        "id": "gn3",
+        "colour": "#00ffff",
+        "fg": "#000",
+        "name": {
+            "zh-Hans": "3号线",
+            "en": "Line 3"
+        }
+    },
+    {
+        "id": "gn4",
+        "colour": "#9900ff",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "4号线",
+            "en": "Line 4"
+        }
+    },
+    {
+        "id": "gn5",
+        "colour": "#ffff00",
+        "fg": "#000",
+        "name": {
+            "zh-Hans": "5号线",
+            "en": "Line 5"
+        }
+    },
+    {
+        "id": "gn s1",
+        "colour": "#0000ff",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "S1号线",
+            "en": "Line S1"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of GuangNan on behalf of poorboy12.
This should fix #408

> @railmapgen/rmg-palette-resources@0.6.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#00ff00}{\textcolor{#000}{Line 1}}$
$\colorbox{#ff0000}{\textcolor{#fff}{Line 2}}$
$\colorbox{#00ffff}{\textcolor{#000}{Line 3}}$
$\colorbox{#9900ff}{\textcolor{#fff}{Line 4}}$
$\colorbox{#ffff00}{\textcolor{#000}{Line 5}}$
$\colorbox{#0000ff}{\textcolor{#fff}{Line S1}}$