### PR TITLE
Resources: New palettes of Jinhua

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -431,6 +431,16 @@
         }
     },
     {
+        "id": "jinhua",
+        "country": "CN",
+        "name": {
+            "zh-Hans": "金华",
+            "en": "Jinhua",
+            "zh-HK": "金華",
+            "zh-TW": "金華"
+        }
+    },
+    {
         "id": "kansai",
         "country": "JP",
         "name": {

--- a/public/resources/palettes/jinhua.json
+++ b/public/resources/palettes/jinhua.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "金义线",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "金义线",
+            "en": "Jinyi Line",
+            "zh-HK": "金義線",
+            "zh-TW": "金義線"
+        }
+    },
+    {
+        "id": "义东线",
+        "colour": "#167cca",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "义东线",
+            "en": "Yidong Line",
+            "zh-HK": "義東線",
+            "zh-TW": "義東線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Jinhua on behalf of leowulinhui.
This should fix #411

> @railmapgen/rmg-palette-resources@0.6.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#ff0000}{\textcolor{#fff}{Jinyi Line}}$
$\colorbox{#167cca}{\textcolor{#fff}{Yidong Line}}$