### PR TITLE
Resources: New palettes of Washington DC

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -955,6 +955,15 @@
         }
     },
     {
+        "id": "washington",
+        "country": "US",
+        "name": {
+            "en": "Washington DC",
+            "zh-Hans": "华盛顿特区",
+            "zh-Hant": "華盛頓特區"
+        }
+    },
+    {
         "id": "wuhan",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/washington.json
+++ b/public/resources/palettes/washington.json
@@ -1,0 +1,62 @@
+[
+    {
+        "id": "rd",
+        "colour": "#e41837",
+        "fg": "#fff",
+        "name": {
+            "en": "Red Line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線"
+        }
+    },
+    {
+        "id": "or",
+        "colour": "#f7941d",
+        "fg": "#000",
+        "name": {
+            "en": "Orange Line",
+            "zh-Hans": "橙线",
+            "zh-Hant": "橙線"
+        }
+    },
+    {
+        "id": "bl",
+        "colour": "#0076c0",
+        "fg": "#fff",
+        "name": {
+            "en": "Blue Line",
+            "zh-Hans": "蓝线",
+            "zh-Hant": "藍線"
+        }
+    },
+    {
+        "id": "gr",
+        "colour": "#00a94f",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線"
+        }
+    },
+    {
+        "id": "yl",
+        "colour": "#ffd201",
+        "fg": "#000",
+        "name": {
+            "en": "Yellow Line",
+            "zh-Hans": "黄线",
+            "zh-Hant": "黃線"
+        }
+    },
+    {
+        "id": "sv",
+        "colour": "#a1a3a1",
+        "fg": "#000",
+        "name": {
+            "en": "Silver Line",
+            "zh-Hans": "银线",
+            "zh-Hant": "銀線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Washington DC on behalf of wongchito.
This should fix #421

> @railmapgen/rmg-palette-resources@0.6.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

$\colorbox{#e41837}{\textcolor{#fff}{Red Line}}$
$\colorbox{#f7941d}{\textcolor{#000}{Orange Line}}$
$\colorbox{#0076c0}{\textcolor{#fff}{Blue Line}}$
$\colorbox{#00a94f}{\textcolor{#fff}{Green Line}}$
$\colorbox{#ffd201}{\textcolor{#000}{Yellow Line}}$
$\colorbox{#a1a3a1}{\textcolor{#000}{Silver Line}}$