### PR TITLE
Resources: New palettes of Yucheng

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -999,6 +999,14 @@
         }
     },
     {
+        "id": "yc",
+        "country": "GBSCT",
+        "name": {
+            "en": "Yucheng",
+            "zh": "雨城"
+        }
+    },
+    {
         "id": "yevpatoria",
         "country": "UA",
         "name": {

--- a/public/resources/palettes/yc.json
+++ b/public/resources/palettes/yc.json
@@ -1,0 +1,11 @@
+[
+    {
+        "id": "circle",
+        "colour": "#edd32c",
+        "fg": "#000",
+        "name": {
+            "en": "Circle Line",
+            "zh": "环线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Yucheng on behalf of WonderLandFpv.
This should fix #423

> @railmapgen/rmg-palette-resources@0.6.28 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Circle Line: background=`#edd32c`, foreground=`#000`