### PR TITLE
Resources: New palettes of Beijing

### DIFF
--- a/public/resources/palettes/beijing.json
+++ b/public/resources/palettes/beijing.json
@@ -72,7 +72,7 @@
     {
         "id": "bj9",
         "colour": "#8fc31f",
-        "fg": "#fff",
+        "fg": "#000",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
@@ -172,7 +172,7 @@
     {
         "id": "bj27cp",
         "colour": "#de82b2",
-        "fg": "#fff",
+        "fg": "#000",
         "name": {
             "en": "Changping Line",
             "zh-Hans": "昌平线",
@@ -202,7 +202,7 @@
     {
         "id": "bj34sj",
         "colour": "#a29bbb",
-        "fg": "#fff",
+        "fg": "#000",
         "name": {
             "en": "Capital Airport Express",
             "zh-Hans": "首都机场线",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Beijing on behalf of NNTR.
This should fix #419

> @railmapgen/rmg-palette-resources@0.6.28 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1/Batong Line: background=`#c23a30`, foreground=`#fff`
Line 2: background=`#006098`, foreground=`#fff`
Line 4/Daxing Line: background=`#008e9c`, foreground=`#fff`
Line 5: background=`#a6217f`, foreground=`#fff`
Line 6: background=`#d29700`, foreground=`#fff`
Line 7: background=`#f6c582`, foreground=`#000`
Line 8: background=`#009b6b`, foreground=`#fff`
Line 9: background=`#8fc31f`, foreground=`#000`
Line 10: background=`#009bc0`, foreground=`#fff`
Line 11: background=`#ED796B`, foreground=`#fff`
Line 13: background=`#f9e700`, foreground=`#000`
Line 14: background=`#d5a7a1`, foreground=`#000`
Line 15: background=`#5b2c68`, foreground=`#fff`
Line 16: background=`#76a32e`, foreground=`#fff`
Line 17: background=`#00A9A9`, foreground=`#fff`
Line 19: background=`#D6ABC1`, foreground=`#000`
Fangshan Line/Yanfang Line: background=`#e46022`, foreground=`#fff`
Changping Line: background=`#de82b2`, foreground=`#000`
Yizhuang Line: background=`#e40077`, foreground=`#fff`
Line S1: background=`#b35a20`, foreground=`#fff`
Capital Airport Express: background=`#a29bbb`, foreground=`#000`
Daxing Airport Express: background=`#004a9f`, foreground=`#fff`
Xijiao Line: background=`#e50619`, foreground=`#fff`
Yizhuang T1 Line: background=`#e5061b`, foreground=`#fff`