### PR TITLE
Resources: New palettes of Nanning

### DIFF
--- a/public/resources/palettes/nanning.json
+++ b/public/resources/palettes/nanning.json
@@ -43,5 +43,32 @@
             "en": "Line 5",
             "zh": "5号线"
         }
+    },
+    {
+        "id": "nn6",
+        "colour": "#f27d00",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh": "6号线"
+        }
+    },
+    {
+        "id": "nn7",
+        "colour": "#945a41",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 7",
+            "zh": "7号线"
+        }
+    },
+    {
+        "id": "nn8",
+        "colour": "#10b3b0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh": "8号线"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanning on behalf of NNTR.
This should fix #393

> @railmapgen/rmg-palette-resources@0.6.30 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#62bd6b`, foreground=`#fff`
Line 2: background=`#ee3d2d`, foreground=`#fff`
Line 3: background=`#a81ba7`, foreground=`#fff`
Line 4: background=`#cdd718`, foreground=`#000`
Line 5: background=`#3a61a8`, foreground=`#fff`
Line 6: background=`#f27d00`, foreground=`#fff`
Line 7: background=`#945a41`, foreground=`#fff`
Line 8: background=`#10b3b0`, foreground=`#fff`