### PR TITLE
Resources: New palettes of Shenzhen

### DIFF
--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -198,5 +198,15 @@
             "zh-Hans": "8号线（原）",
             "zh-Hant": "8號線（原）"
         }
+    },
+    {
+        "id": "szpsyb",
+        "colour": "#1974d2",
+        "fg": "#fff",
+        "name": {
+            "en": "Pingshan sky shuttlo",
+            "zh-Hans": "坪山云巴",
+            "zh-Hant": "坪山雲巴"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenzhen on behalf of NNTR.
This should fix #410

> @railmapgen/rmg-palette-resources@0.6.30 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1 (Luobao Line): background=`#00B140`, foreground=`#fff`
Line 2 (Shekou Line): background=`#B94700`, foreground=`#fff`
Line 3 (Longgang Line): background=`#00A9E0`, foreground=`#fff`
Line 4 (Longhua Line): background=`#DA291C`, foreground=`#fff`
Line 5 (Huanzhong Line): background=`#A05EB5`, foreground=`#fff`
Line 6: background=`#00C7B1`, foreground=`#fff`
Line 6 branch: background=`#168773`, foreground=`#fff`
Line 7: background=`#0033A0`, foreground=`#fff`
Line 8: background=`#b94700`, foreground=`#fff`
Line 9: background=`#7B6469`, foreground=`#fff`
Line 10: background=`#F8779E`, foreground=`#fff`
Line 11: background=`#672146`, foreground=`#fff`
Line 12: background=`#A192B2`, foreground=`#fff`
Line 13: background=`#DE7C00`, foreground=`#fff`
Line 14: background=`#F2C75C`, foreground=`#fff`
Line 15: background=`#84BD00`, foreground=`#fff`
Line 16: background=`#1E22AA`, foreground=`#fff`
Line 20: background=`#88DBDF`, foreground=`#fff`
Tram: background=`#b8b8b8`, foreground=`#fff`
Line 8 (Original): background=`#E45DBF`, foreground=`#fff`
Pingshan sky shuttlo: background=`#1974d2`, foreground=`#fff`