### PR TITLE
Resources: New palettes of Zhengzhou

### DIFF
--- a/public/resources/palettes/zhengzhou.json
+++ b/public/resources/palettes/zhengzhou.json
@@ -84,9 +84,9 @@
         "colour": "#828C47",
         "fg": "#fff",
         "name": {
-            "en": "Suburban Line",
-            "zh-Hans": "城郊线",
-            "zh-Hant": "城郊線"
+            "en": "Line 9 Suburban Line",
+            "zh-Hans": "9 - 城郊线",
+            "zh-Hant": "9 - 城郊線"
         }
     },
     {

--- a/public/resources/palettes/zhengzhou.json
+++ b/public/resources/palettes/zhengzhou.json
@@ -84,9 +84,9 @@
         "colour": "#828C47",
         "fg": "#fff",
         "name": {
-            "en": "Line 9 Suburban Line",
-            "zh-Hans": "9 - 城郊线",
-            "zh-Hant": "9 - 城郊線"
+            "en": "Suburban Line",
+            "zh-Hans": "城郊线",
+            "zh-Hant": "城郊線"
         }
     },
     {
@@ -124,9 +124,9 @@
         "colour": "#1D4155",
         "fg": "#fff",
         "name": {
-            "en": "Line 17 Zhengxu Line",
-            "zh-Hans": "17 - 郑许市域铁路",
-            "zh-Hant": "17 - 鄭許市域鐵路"
+            "en": "Line 17 (Zhengxu Line)",
+            "zh-Hans": "17号线（郑许市域铁路）",
+            "zh-Hant": "17號線（鄭許市域鐵路）"
         }
     }
 ]

--- a/public/resources/palettes/zhengzhou.json
+++ b/public/resources/palettes/zhengzhou.json
@@ -124,9 +124,9 @@
         "colour": "#1D4155",
         "fg": "#fff",
         "name": {
-            "en": "Zhengxu Line",
-            "zh-Hans": "郑许线",
-            "zh-Hant": "鄭許線"
+            "en": "Line 17 Zhengxu Line",
+            "zh-Hans": "17 - 郑许市域铁路",
+            "zh-Hant": "17 - 鄭許市域鐵路"
         }
     }
 ]

--- a/public/resources/palettes/zhengzhou.json
+++ b/public/resources/palettes/zhengzhou.json
@@ -1,119 +1,132 @@
 [
     {
         "id": "zz1",
+        "colour": "#D20200",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#D20200"
+        }
     },
     {
         "id": "zz2",
+        "colour": "#D28F00",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#D28F00"
+        }
     },
     {
         "id": "zz3",
+        "colour": "#CB5100",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#CB5100"
+        }
     },
     {
         "id": "zz4",
+        "colour": "#3792D6",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#3792D6"
+        }
     },
     {
         "id": "zz5",
+        "colour": "#25AC74",
+        "fg": "#fff",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
             "zh-Hant": "5號線"
-        },
-        "colour": "#25AC74"
+        }
     },
     {
         "id": "zz6",
+        "colour": "#852081",
+        "fg": "#fff",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
             "zh-Hant": "6號線"
-        },
-        "colour": "#852081"
+        }
     },
     {
         "id": "zz7",
+        "colour": "#C0955A",
+        "fg": "#fff",
         "name": {
             "en": "Line 7",
             "zh-Hans": "7号线",
             "zh-Hant": "7號線"
-        },
-        "colour": "#C0955A"
+        }
     },
     {
         "id": "zz8",
+        "colour": "#E6E394",
+        "fg": "#fff",
         "name": {
             "en": "Line 8",
             "zh-Hans": "8号线",
             "zh-Hant": "8號線"
-        },
-        "colour": "#E6E394"
+        }
     },
     {
         "id": "zz9",
+        "colour": "#828C47",
+        "fg": "#fff",
         "name": {
             "en": "Suburban Line",
             "zh-Hans": "城郊线",
             "zh-Hant": "城郊線"
-        },
-        "colour": "#828C47"
+        }
     },
     {
         "id": "zz10",
+        "colour": "#B15F56",
+        "fg": "#fff",
         "name": {
             "en": "Line 10",
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
-        },
-        "colour": "#B15F56"
+        }
     },
     {
         "id": "zz12",
+        "colour": "#225E9E",
+        "fg": "#fff",
         "name": {
             "en": "Line 12",
             "zh-Hans": "12号线",
             "zh-Hant": "12號線"
-        },
-        "colour": "#225E9E"
+        }
     },
     {
         "id": "zz14",
+        "colour": "#844F7C",
+        "fg": "#fff",
         "name": {
             "en": "Line 14",
             "zh-Hans": "14号线",
             "zh-Hant": "14號線"
-        },
-        "colour": "#844F7C"
+        }
     },
     {
         "id": "zz17",
+        "colour": "#1D4155",
+        "fg": "#fff",
         "name": {
-            "en": "Line 17",
-            "zh-Hans": "17号线",
-            "zh-Hant": "17號線"
-        },
-        "colour": "#1D4155"
+            "en": "Zhengxu Line",
+            "zh-Hans": "郑许线",
+            "zh-Hant": "鄭許線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Zhengzhou on behalf of C1P918R.
This should fix #437

> @railmapgen/rmg-palette-resources@0.6.31 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#D20200`, foreground=`#fff`
Line 2: background=`#D28F00`, foreground=`#fff`
Line 3: background=`#CB5100`, foreground=`#fff`
Line 4: background=`#3792D6`, foreground=`#fff`
Line 5: background=`#25AC74`, foreground=`#fff`
Line 6: background=`#852081`, foreground=`#fff`
Line 7: background=`#C0955A`, foreground=`#fff`
Line 8: background=`#E6E394`, foreground=`#fff`
Suburban Line: background=`#828C47`, foreground=`#fff`
Line 10: background=`#B15F56`, foreground=`#fff`
Line 12: background=`#225E9E`, foreground=`#fff`
Line 14: background=`#844F7C`, foreground=`#fff`
Zhengxu Line: background=`#1D4155`, foreground=`#fff`