### PR TITLE
Resources: New palettes of Munich

### DIFF
--- a/public/resources/palettes/munich.json
+++ b/public/resources/palettes/munich.json
@@ -66,6 +66,17 @@
         }
     },
     {
+        "id": "mu9",
+        "colour": "#009fe3",
+        "fg": "#fff",
+        "name": {
+            "en": "U9",
+            "de": "U9",
+            "zh-Hans": "9号线",
+            "zh-Hant": "9號線"
+        }
+    },
+    {
         "id": "ms1",
         "colour": "#15BFE9",
         "fg": "#fff",
@@ -109,7 +120,7 @@
             "zh-Hant": "市域S4"
         }
     },
-   {
+    {
         "id": "ms6",
         "colour": "#00975f",
         "fg": "#fff",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Munich on behalf of linchen1965.
This should fix #451

> @railmapgen/rmg-palette-resources@0.7.0 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

U1: background=`#438136`, foreground=`#fff`
U2: background=`#C40C37`, foreground=`#fff`
U3: background=`#F36E31`, foreground=`#fff`
U4: background=`#0AB38D`, foreground=`#fff`
U5: background=`#B8740E`, foreground=`#fff`
U6: background=`#006CB3`, foreground=`#fff`
U9: background=`#009fe3`, foreground=`#fff`
S1: background=`#15BFE9`, foreground=`#fff`
S2: background=`#71BF44`, foreground=`#fff`
S3: background=`#90268F`, foreground=`#fff`
S4: background=`#EE1C28`, foreground=`#fff`
S6: background=`#00975f`, foreground=`#fff`
S7: background=`#88322C`, foreground=`#fff`
S8: background=`#EFA83C`, foreground=`#fff`
S20: background=`#F05972`, foreground=`#fff`
Regional Train: background=`#313D85`, foreground=`#fff`