### PR TITLE
Resources: New palettes of Xuzhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -999,6 +999,15 @@
         }
     },
     {
+        "id": "xuzhou",
+        "country": "CN",
+        "name": {
+            "en": "Xuzhou",
+            "zh-Hans": "徐州",
+            "zh-Hant": "徐州"
+        }
+    },
+    {
         "id": "yevpatoria",
         "country": "UA",
         "name": {

--- a/public/resources/palettes/xuzhou.json
+++ b/public/resources/palettes/xuzhou.json
@@ -1,0 +1,32 @@
+[
+    {
+        "id": "xz1",
+        "colour": "#a43337",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hant": "1號線",
+            "zh-Hans": "1号线"
+        }
+    },
+    {
+        "id": "xz2",
+        "colour": "#f08300",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hant": "2號線",
+            "zh-Hans": "2号线"
+        }
+    },
+    {
+        "id": "xz3",
+        "colour": "#008cd7",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hant": "3號線",
+            "zh-Hans": "3号线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Xuzhou on behalf of linchen1965.
This should fix #453

> @railmapgen/rmg-palette-resources@0.7.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#a43337`, foreground=`#fff`
Line 2: background=`#f08300`, foreground=`#fff`
Line 3: background=`#008cd7`, foreground=`#fff`