### PR TITLE
Resources: New palettes of Suzhou

### DIFF
--- a/public/resources/palettes/suzhou.json
+++ b/public/resources/palettes/suzhou.json
@@ -1,47 +1,102 @@
 [
     {
         "id": "sz1",
+        "colour": "#78BA25",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#78BA25"
+        }
     },
     {
         "id": "sz2",
+        "colour": "#ED3240",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#ED3240"
+        }
     },
     {
         "id": "sz3",
+        "colour": "#F88211",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#F88211"
+        }
     },
     {
         "id": "sz4",
+        "colour": "#196EAE",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#196EAE"
+        }
     },
     {
         "id": "sz5",
+        "colour": "#E63A9A",
+        "fg": "#fff",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
             "zh-Hant": "5號線"
-        },
-        "colour": "#E63A9A"
+        }
+    },
+    {
+        "id": "sz6",
+        "colour": "#41b6e6",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號線"
+        }
+    },
+    {
+        "id": "sz7",
+        "colour": "#a77bca",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 7",
+            "zh-Hans": "7号线",
+            "zh-Hant": "7號線"
+        }
+    },
+    {
+        "id": "sz8",
+        "colour": "#a09200",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號線"
+        }
+    },
+    {
+        "id": "sz10",
+        "colour": "#ca9a8e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 10",
+            "zh-Hans": "10号线",
+            "zh-Hant": "10號線"
+        }
+    },
+    {
+        "id": "sz11",
+        "colour": "#f1c6a6",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 11",
+            "zh-Hans": "11号线",
+            "zh-Hant": "11號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Suzhou on behalf of NNTR.
This should fix #449

> @railmapgen/rmg-palette-resources@0.7.2 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#78BA25`, foreground=`#fff`
Line 2: background=`#ED3240`, foreground=`#fff`
Line 3: background=`#F88211`, foreground=`#fff`
Line 4: background=`#196EAE`, foreground=`#fff`
Line 5: background=`#E63A9A`, foreground=`#fff`
Line 6: background=`#41b6e6`, foreground=`#fff`
Line 7: background=`#a77bca`, foreground=`#fff`
Line 8: background=`#a09200`, foreground=`#fff`
Line 10: background=`#ca9a8e`, foreground=`#fff`
Line 11: background=`#f1c6a6`, foreground=`#fff`