### PR TITLE
Resources: New palettes of Test

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -896,6 +896,13 @@
         }
     },
     {
+        "id": "test",
+        "country": "HK",
+        "name": {
+            "en": "Test"
+        }
+    },
+    {
         "id": "tianjin",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/test.json
+++ b/public/resources/palettes/test.json
@@ -1,0 +1,10 @@
+[
+    {
+        "id": "test",
+        "colour": "#aaaaaa",
+        "fg": "#fff",
+        "name": {
+            "en": "Test"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Test on behalf of wongchito.
This should fix #459

> @railmapgen/rmg-palette-resources@0.7.3 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Test: background=`#aaaaaa`, foreground=`#fff`