### PR TITLE
Resources: New palettes of Taoyuan

### DIFF
--- a/public/resources/palettes/taoyuan.json
+++ b/public/resources/palettes/taoyuan.json
@@ -5,36 +5,38 @@
         "fg": "#fff",
         "name": {
             "en": "Taoyuan Airport MRT",
-            "zh-CN": "桃园机场捷运",
-            "zh-TW": "桃園機場捷運",
-            "zh-HK": "桃園機場捷運"
+            "zh-Hans": "桃园机场捷运",
+            "zh-Hant": "桃園機場捷運"
         }
     },
     {
-        "id": "",
+        "id": "g",
         "colour": "#62a033",
         "fg": "#fff",
         "name": {
             "en": "Green Line",
-            "zh-TW": "綠線"
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線"
         }
     },
     {
-        "id": "",
+        "id": "o",
         "colour": "#ffa500",
         "fg": "#fff",
         "name": {
             "en": "Orange Line",
-            "zh-TW": "橘線"
+            "zh-Hans": "橘线",
+            "zh-Hant": "橘線"
         }
     },
     {
-        "id": "",
+        "id": "br",
         "colour": "#824729",
         "fg": "#fff",
         "name": {
             "en": "Brown Line",
-            "zh-TW": "棕線"
+            "zh-Hans": "棕线",
+            "zh-Hant": "棕線"
         }
     }
 ]

--- a/public/resources/palettes/taoyuan.json
+++ b/public/resources/palettes/taoyuan.json
@@ -9,5 +9,32 @@
             "zh-TW": "桃園機場捷運",
             "zh-HK": "桃園機場捷運"
         }
+    },
+    {
+        "id": "",
+        "colour": "#62a033",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-TW": "綠線"
+        }
+    },
+    {
+        "id": "",
+        "colour": "#ffa500",
+        "fg": "#fff",
+        "name": {
+            "en": "Orange Line",
+            "zh-TW": "橘線"
+        }
+    },
+    {
+        "id": "",
+        "colour": "#824729",
+        "fg": "#fff",
+        "name": {
+            "en": "Brown Line",
+            "zh-TW": "棕線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Taoyuan on behalf of riyukiK.
This should fix #461

> @railmapgen/rmg-palette-resources@0.7.3 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Taoyuan Airport MRT: background=`#8246af`, foreground=`#fff`
Green Line: background=`#62a033`, foreground=`#fff`
Orange Line: background=`#ffa500`, foreground=`#fff`
Brown Line: background=`#824729`, foreground=`#fff`