### PR TITLE
Resources: New palettes of Shanghai

### DIFF
--- a/public/resources/palettes/shanghai.json
+++ b/public/resources/palettes/shanghai.json
@@ -1,8 +1,9 @@
 [
     {
         "id": "sh1",
-        "colour": "#E3002B",
+        "colour": "#E4002B",
         "fg": "#fff",
+        "pantone": "185 C",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
@@ -11,8 +12,9 @@
     },
     {
         "id": "sh2",
-        "colour": "#8CC220",
+        "colour": "#97D700",
         "fg": "#000",
+        "pantone": "375 C",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
@@ -21,8 +23,9 @@
     },
     {
         "id": "sh3",
-        "colour": "#FCD600",
+        "colour": "#FFD100",
         "fg": "#000",
+        "pantone": "109 C",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
@@ -31,8 +34,9 @@
     },
     {
         "id": "sh4",
-        "colour": "#461D84",
+        "colour": "#5F249F",
         "fg": "#fff",
+        "pantone": "267 C",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
@@ -41,8 +45,9 @@
     },
     {
         "id": "sh5",
-        "colour": "#944D9A",
+        "colour": "#AC4FC6",
         "fg": "#fff",
+        "pantone": "2582 C",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
@@ -51,8 +56,9 @@
     },
     {
         "id": "sh6",
-        "colour": "#D40068",
+        "colour": "#D60078",
         "fg": "#fff",
+        "pantone": "Process Magenta C",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
@@ -61,8 +67,9 @@
     },
     {
         "id": "sh7",
-        "colour": "#ED6F00",
+        "colour": "#FF6900",
         "fg": "#000",
+        "pantone": "1505 C",
         "name": {
             "en": "Line 7",
             "zh-Hans": "7号线",
@@ -71,8 +78,9 @@
     },
     {
         "id": "sh8",
-        "colour": "#0094D8",
+        "colour": "#009CDD",
         "fg": "#fff",
+        "pantone": "Process Cyan C",
         "name": {
             "en": "Line 8",
             "zh-Hans": "8号线",
@@ -81,8 +89,9 @@
     },
     {
         "id": "sh9",
-        "colour": "#87CAED",
+        "colour": "#71C5E8",
         "fg": "#000",
+        "pantone": "297 C",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
@@ -91,8 +100,9 @@
     },
     {
         "id": "sh10",
-        "colour": "#C6AFD4",
+        "colour": "#C1A7E2",
         "fg": "#000",
+        "pantone": "264 C",
         "name": {
             "en": "Line 10",
             "zh-Hans": "10号线",
@@ -101,8 +111,9 @@
     },
     {
         "id": "sh11",
-        "colour": "#871C2B",
+        "colour": "#76232F",
         "fg": "#fff",
+        "pantone": "188 C",
         "name": {
             "en": "Line 11",
             "zh-Hans": "11号线",
@@ -111,8 +122,9 @@
     },
     {
         "id": "sh12",
-        "colour": "#007B61",
+        "colour": "#007B5F",
         "fg": "#fff",
+        "pantone": "335 C",
         "name": {
             "en": "Line 12",
             "zh-Hans": "12号线",
@@ -121,8 +133,9 @@
     },
     {
         "id": "sh13",
-        "colour": "#E999C0",
+        "colour": "#EF95CF",
         "fg": "#000",
+        "pantone": "223 C",
         "name": {
             "en": "Line 13",
             "zh-Hans": "13号线",
@@ -131,8 +144,9 @@
     },
     {
         "id": "sh14",
-        "colour": "#626020",
+        "colour": "#827A04",
         "fg": "#fff",
+        "pantone": "392 C",
         "name": {
             "en": "Line 14",
             "zh-Hans": "14号线",
@@ -141,8 +155,9 @@
     },
     {
         "id": "sh15",
-        "colour": "#BCA886",
+        "colour": "#CEB888",
         "fg": "#000",
+        "pantone": "7502 C",
         "name": {
             "en": "Line 15",
             "zh-Hans": "15号线",
@@ -151,8 +166,9 @@
     },
     {
         "id": "sh16",
-        "colour": "#98D1C0",
+        "colour": "#2CD5C4",
         "fg": "#000",
+        "pantone": "3255 C",
         "name": {
             "en": "Line 16",
             "zh-Hans": "16号线",
@@ -161,8 +177,9 @@
     },
     {
         "id": "sh17",
-        "colour": "#BC796F",
+        "colour": "#C09C83",
         "fg": "#fff",
+        "pantone": "7521 C",
         "name": {
             "en": "Line 17",
             "zh-Hans": "17号线",
@@ -171,8 +188,9 @@
     },
     {
         "id": "sh18",
-        "colour": "#C4984F",
+        "colour": "#D6A461",
         "fg": "#000",
+        "pantone": "7509 C",
         "name": {
             "en": "Line 18",
             "zh-Hans": "18号线",
@@ -181,8 +199,9 @@
     },
     {
         "id": "pjl",
-        "colour": "#B5B5B6",
+        "colour": "#9EA2A2",
         "fg": "#fff",
+        "pantone": "422 C",
         "name": {
             "en": "Pujiang Line",
             "zh-Hans": "浦江线",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shanghai on behalf of wongchito.
This should fix #466

> @railmapgen/rmg-palette-resources@0.7.4 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#E4002B`, foreground=`#fff`
Line 2: background=`#97D700`, foreground=`#000`
Line 3: background=`#FFD100`, foreground=`#000`
Line 4: background=`#5F249F`, foreground=`#fff`
Line 5: background=`#AC4FC6`, foreground=`#fff`
Line 6: background=`#D60078`, foreground=`#fff`
Line 7: background=`#FF6900`, foreground=`#000`
Line 8: background=`#009CDD`, foreground=`#fff`
Line 9: background=`#71C5E8`, foreground=`#000`
Line 10: background=`#C1A7E2`, foreground=`#000`
Line 11: background=`#76232F`, foreground=`#fff`
Line 12: background=`#007B5F`, foreground=`#fff`
Line 13: background=`#EF95CF`, foreground=`#000`
Line 14: background=`#827A04`, foreground=`#fff`
Line 15: background=`#CEB888`, foreground=`#000`
Line 16: background=`#2CD5C4`, foreground=`#000`
Line 17: background=`#C09C83`, foreground=`#fff`
Line 18: background=`#D6A461`, foreground=`#000`
Pujiang Line: background=`#9EA2A2`, foreground=`#fff`
Songjiang Tram T1: background=`#FF0000`, foreground=`#fff`
Songjiang Tram T2: background=`#46837B`, foreground=`#fff`
Songjiang Tram T3: background=`#009400`, foreground=`#fff`
Songjiang Tram T4: background=`#FF00FF`, foreground=`#fff`
Songjiang Tram T5: background=`#00FD00`, foreground=`#fff`
Songjiang Tram T6: background=`#6E00DD`, foreground=`#fff`
Shanghai Maglev Train: background=`#009090`, foreground=`#fff`
Jinshan Railway: background=`#000000`, foreground=`#fff`