### PR TITLE
Resources: New palettes of Chongqing

### DIFF
--- a/public/resources/palettes/chongqing.json
+++ b/public/resources/palettes/chongqing.json
@@ -188,5 +188,25 @@
             "zh-Hans": "18号线",
             "zh-Hant": "18號線"
         }
+    },
+    {
+        "id": "cq27",
+        "colour": "#ffc638",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 27",
+            "zh-Hans": "27号线",
+            "zh-Hant": "27號線"
+        }
+    },
+    {
+        "id": "cq24",
+        "colour": "#326f67",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 24",
+            "zh-Hans": "24号线",
+            "zh-Hant": "24號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Chongqing on behalf of xiguagreen.
This should fix #471

> @railmapgen/rmg-palette-resources@0.7.4 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Loop Line: background=`#A89968`, foreground=`#fff`
Line 1: background=`#E4002B`, foreground=`#fff`
Line 2: background=`#007A33`, foreground=`#fff`
Line 3: background=`#003DA5`, foreground=`#fff`
Line 4: background=`#DC8633`, foreground=`#fff`
Line 5: background=`#00A3E0`, foreground=`#fff`
Line 6: background=`#F67599`, foreground=`#fff`
Line 7: background=`#008C95`, foreground=`#fff`
Line 8: background=`#7A9A01`, foreground=`#fff`
Line 9: background=`#862041`, foreground=`#fff`
Line 10: background=`#5F249F`, foreground=`#fff`
Line 11: background=`#D986BA`, foreground=`#fff`
Line 12: background=`#D2D755`, foreground=`#fff`
Line 13: background=`#B89D18`, foreground=`#fff`
Line 14: background=`#B94700`, foreground=`#fff`
Line 15: background=`#0057B7`, foreground=`#fff`
Line 16: background=`#B04A5A`, foreground=`#fff`
Line 17: background=`#9F5CC0`, foreground=`#fff`
Line 18: background=`#3cdbc0`, foreground=`#fff`
Line 27: background=`#ffc638`, foreground=`#fff`
Line 24: background=`#326f67`, foreground=`#fff`