### PR TITLE
Resources: New palettes of Rome

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -726,6 +726,17 @@
         }
     },
     {
+        "id": "rome",
+        "country": "IT",
+        "name": {
+            "en": "Rome",
+            "ko": "로마",
+            "zh-Hans": "罗马",
+            "zh-Hant": "羅馬",
+            "it": "Roma"
+        }
+    },
+    {
         "id": "sanfrancisco",
         "country": "US",
         "name": {

--- a/public/resources/palettes/rome.json
+++ b/public/resources/palettes/rome.json
@@ -1,0 +1,50 @@
+[
+    {
+        "id": "rma",
+        "colour": "#f36c21",
+        "fg": "#fff",
+        "name": {
+            "en": "Line A",
+            "ko": "A선",
+            "zh-Hans": "A线",
+            "zh-Hant": "A線",
+            "it": "Linea A"
+        }
+    },
+    {
+        "id": "rmb",
+        "colour": "#0071bb",
+        "fg": "#fff",
+        "name": {
+            "en": "Line B",
+            "ko": "B선",
+            "zh-Hans": "B线",
+            "zh-Hant": "B線",
+            "it": "Linea B"
+        }
+    },
+    {
+        "id": "rmc",
+        "colour": "#008751",
+        "fg": "#fff",
+        "name": {
+            "en": "Line C",
+            "ko": "C선",
+            "zh-Hans": "C线",
+            "zh-Hant": "C線",
+            "it": "Linea C"
+        }
+    },
+    {
+        "id": "rmld",
+        "colour": "#33bdef",
+        "fg": "#fff",
+        "name": {
+            "en": "Rome–Lido railway",
+            "ko": "로마-리도 철도",
+            "zh-Hans": "罗马-利多铁路",
+            "zh-Hant": "羅馬-利多鐵路",
+            "it": "Ferrovia Roma-Lido"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Rome on behalf of linchen1965.
This should fix #476

> @railmapgen/rmg-palette-resources@0.7.4 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line A: background=`#f36c21`, foreground=`#fff`
Line B: background=`#0071bb`, foreground=`#fff`
Line C: background=`#008751`, foreground=`#fff`
Rome–Lido railway: background=`#33bdef`, foreground=`#fff`