### PR TITLE
Resources: New palettes of Chongqing

### DIFF
--- a/public/resources/palettes/chongqing.json
+++ b/public/resources/palettes/chongqing.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "loop",
-        "colour": "#A89968",
+        "colour": "#f2a900",
         "fg": "#fff",
         "name": {
             "en": "Loop Line",
@@ -21,7 +21,7 @@
     },
     {
         "id": "cq2",
-        "colour": "#007A33",
+        "colour": "#007033",
         "fg": "#fff",
         "name": {
             "en": "Line 2",
@@ -91,7 +91,7 @@
     },
     {
         "id": "cq9",
-        "colour": "#862041",
+        "colour": "#861f41",
         "fg": "#fff",
         "name": {
             "en": "Line 9",
@@ -101,7 +101,7 @@
     },
     {
         "id": "cq10",
-        "colour": "#5F249F",
+        "colour": "#5f259f",
         "fg": "#fff",
         "name": {
             "en": "Line 10",
@@ -151,7 +151,7 @@
     },
     {
         "id": "cq15",
-        "colour": "#0057B7",
+        "colour": "#0057b8",
         "fg": "#fff",
         "name": {
             "en": "Line 15",
@@ -181,12 +181,42 @@
     },
     {
         "id": "cq18",
-        "colour": "#3cdbc0",
+        "colour": "#2ad2c9",
         "fg": "#fff",
         "name": {
             "en": "Line 18",
             "zh-Hans": "18号线",
             "zh-Hant": "18號線"
+        }
+    },
+    {
+        "id": "cq24",
+        "colour": "#00a3ad",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 24",
+            "zh-Hans": "24号线",
+            "zh-Hant": "24號線"
+        }
+    },
+    {
+        "id": "cq27",
+        "colour": "#685bc7",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 27",
+            "zh-Hans": "27号线",
+            "zh-Hant": "27號線"
+        }
+    },
+    {
+        "id": "jiangtiao",
+        "colour": "#0077c8",
+        "fg": "#fff",
+        "name": {
+            "en": "Jiangtiao Line",
+            "zh-Hans": "江跳线",
+            "zh-Hant": "江跳線"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Chongqing on behalf of Jinkelavicii.
This should fix #480

> @railmapgen/rmg-palette-resources@0.7.5 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Loop Line: background=`#f2a900`, foreground=`#fff`
Line 1: background=`#E4002B`, foreground=`#fff`
Line 2: background=`#007033`, foreground=`#fff`
Line 3: background=`#003DA5`, foreground=`#fff`
Line 4: background=`#DC8633`, foreground=`#fff`
Line 5: background=`#00A3E0`, foreground=`#fff`
Line 6: background=`#F67599`, foreground=`#fff`
Line 7: background=`#008C95`, foreground=`#fff`
Line 8: background=`#7A9A01`, foreground=`#fff`
Line 9: background=`#861f41`, foreground=`#fff`
Line 10: background=`#5f259f`, foreground=`#fff`
Line 11: background=`#D986BA`, foreground=`#fff`
Line 12: background=`#D2D755`, foreground=`#fff`
Line 13: background=`#B89D18`, foreground=`#fff`
Line 14: background=`#B94700`, foreground=`#fff`
Line 15: background=`#0057b8`, foreground=`#fff`
Line 16: background=`#B04A5A`, foreground=`#fff`
Line 17: background=`#9F5CC0`, foreground=`#fff`
Line 18: background=`#2ad2c9`, foreground=`#fff`
Line 24: background=`#00a3ad`, foreground=`#fff`
Line 27: background=`#685bc7`, foreground=`#fff`
Jiangtiao Line: background=`#0077c8`, foreground=`#fff`