### PR TITLE
Resources: New palettes of Fuzhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -294,6 +294,17 @@
         }
     },
     {
+        "id": "fuzhou",
+        "country": "CN",
+        "name": {
+            "en": "Fuzhou",
+            "ko": "푸저우",
+            "zh-Hans": "福州",
+            "zh-TW": "福州",
+            "zh-HK": "福州"
+        }
+    },
+    {
         "id": "glasgow",
         "country": "GBSCT",
         "name": {

--- a/public/resources/palettes/fuzhou.json
+++ b/public/resources/palettes/fuzhou.json
@@ -1,0 +1,74 @@
+[
+    {
+        "id": "fz1",
+        "colour": "#bb1e10",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "ko": "1호선",
+            "zh-Hans": "1号线",
+            "zh-HK": "1號綫",
+            "zh-TW": "1號缐"
+        }
+    },
+    {
+        "id": "fz2",
+        "colour": "#325928",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "ko": "2호선",
+            "zh-Hans": "2号线",
+            "zh-HK": "2號綫",
+            "zh-TW": "2號缐"
+        }
+    },
+    {
+        "id": "fz4",
+        "colour": "#ff7f41",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "ko": "4호선",
+            "zh-Hans": "4号线",
+            "zh-HK": "4號綫",
+            "zh-TW": "4號缐"
+        }
+    },
+    {
+        "id": "fz5",
+        "colour": "#893b67",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "ko": "5호선",
+            "zh-Hans": "5号线",
+            "zh-HK": "5號綫",
+            "zh-TW": "5號缐"
+        }
+    },
+    {
+        "id": "fz6",
+        "colour": "#005eb8",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "ko": "6호선",
+            "zh-Hans": "6号线",
+            "zh-HK": "6號綫",
+            "zh-TW": "6號缐"
+        }
+    },
+    {
+        "id": "fzbh",
+        "colour": "#00adbb",
+        "fg": "#fff",
+        "name": {
+            "en": "Binhai Express",
+            "ko": "빈해 익스프레스",
+            "zh-Hans": "滨海快线",
+            "zh-HK": "濱海快綫",
+            "zh-TW": "濱海快缐"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Fuzhou on behalf of TakeiDaisei.
This should fix #447

> @railmapgen/rmg-palette-resources@0.7.5 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#bb1e10`, foreground=`#fff`
Line 2: background=`#325928`, foreground=`#fff`
Line 4: background=`#ff7f41`, foreground=`#fff`
Line 5: background=`#893b67`, foreground=`#fff`
Line 6: background=`#005eb8`, foreground=`#fff`
Binhai Express: background=`#00adbb`, foreground=`#fff`