### PR TITLE
Resources: New palettes of Paris

### DIFF
--- a/public/resources/palettes/paris.json
+++ b/public/resources/palettes/paris.json
@@ -88,6 +88,17 @@
         }
     },
     {
+        "id": "m7b",
+        "colour": "#84c28e",
+        "fg": "#000",
+        "name": {
+            "en": "Metro Line 7b",
+            "fr": "Métro Ligne 7b",
+            "zh-Hans": "地铁7b号线",
+            "zh-Hant": "地鐵7b號線"
+        }
+    },
+    {
         "id": "m8",
         "colour": "#CEADD2",
         "fg": "#000",
@@ -349,8 +360,19 @@
         }
     },
     {
+        "id": "t13",
+        "colour": "#6e491e",
+        "fg": "#fff",
+        "name": {
+            "en": "Tramway Line 13",
+            "fr": "Tramway Ligne 13",
+            "zh-Hans": "有轨电车T13号线",
+            "zh-Hant": "有軌電車T13號線"
+        }
+    },
+    {
         "id": "trainh",
-        "colour": "#A1565C",
+        "colour": "#8c602b",
         "fg": "#fff",
         "name": {
             "en": "Transilien Line H",
@@ -359,7 +381,7 @@
     },
     {
         "id": "trainj",
-        "colour": "#C7D530",
+        "colour": "#d2ce00",
         "fg": "#000",
         "name": {
             "en": "Transilien Line J",
@@ -368,7 +390,7 @@
     },
     {
         "id": "traink",
-        "colour": "#C2A712",
+        "colour": "#9d9b22",
         "fg": "#fff",
         "name": {
             "en": "Transilien Line K",
@@ -377,7 +399,7 @@
     },
     {
         "id": "trainl",
-        "colour": "#7784C0",
+        "colour": "#ceaacf",
         "fg": "#000",
         "name": {
             "en": "Transilien Line L",
@@ -386,7 +408,7 @@
     },
     {
         "id": "trainn",
-        "colour": "#27B4AE",
+        "colour": "#00aa8f",
         "fg": "#fff",
         "name": {
             "en": "Transilien Line N",
@@ -395,7 +417,7 @@
     },
     {
         "id": "trainp",
-        "colour": "#FAB31E",
+        "colour": "#f2933d",
         "fg": "#000",
         "name": {
             "en": "Transilien Line P",
@@ -404,7 +426,7 @@
     },
     {
         "id": "trainr",
-        "colour": "#EEC0DB",
+        "colour": "#f2a4b7",
         "fg": "#000",
         "name": {
             "en": "Transilien Line R",
@@ -413,7 +435,7 @@
     },
     {
         "id": "trainu",
-        "colour": "#E5006D",
+        "colour": "#be0045",
         "fg": "#fff",
         "name": {
             "en": "Transilien Line U",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Paris on behalf of linchen1965.
This should fix #483

> @railmapgen/rmg-palette-resources@0.7.6 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Metro Line 1: background=`#FFCE00`, foreground=`#000`
Metro Line 2: background=`#0064B0`, foreground=`#fff`
Metro Line 3: background=`#9F9825`, foreground=`#fff`
Metro Line 3b: background=`#98D4E2`, foreground=`#000`
Metro Line 4: background=`#C04191`, foreground=`#fff`
Metro Line 5: background=`#F28E42`, foreground=`#000`
Metro Line 6: background=`#83C491`, foreground=`#000`
Metro Line 7: background=`#F3A4BA`, foreground=`#000`
Metro Line 7b: background=`#84c28e`, foreground=`#000`
Metro Line 8: background=`#CEADD2`, foreground=`#000`
Metro Line 9: background=`#D5C900`, foreground=`#000`
Metro Line 10: background=`#E3B32A`, foreground=`#000`
Metro Line 11: background=`#8D5E2A`, foreground=`#fff`
Metro Line 12: background=`#00814F`, foreground=`#fff`
Metro Line 13: background=`#98D4E2`, foreground=`#000`
Metro Line 14: background=`#662483`, foreground=`#fff`
OrlyVal: background=`#FFCD0D`, foreground=`#fff`
RER Line A: background=`#E3051C`, foreground=`#fff`
RER Line B: background=`#5291CE`, foreground=`#fff`
RER Line C: background=`#F6D200`, foreground=`#000`
RER Line D: background=`#009E59`, foreground=`#fff`
RER Line E: background=`#D682B5`, foreground=`#fff`
Tramway Line 1: background=`#0064B0`, foreground=`#fff`
Tramway Line 2: background=`#C04191`, foreground=`#fff`
Tramway Line 3a: background=`#F28E42`, foreground=`#fff`
Tramway Line 3b: background=`#009E59`, foreground=`#fff`
Tramway Line 4: background=`#FAB31E`, foreground=`#fff`
Tramway Line 5: background=`#662483`, foreground=`#fff`
Tramway Line 6: background=`#E3051C`, foreground=`#fff`
Tramway Line 7: background=`#8D5E2A`, foreground=`#fff`
Tramway Line 8: background=`#9F9825`, foreground=`#fff`
Tramway Line 9: background=`#4F8FCC`, foreground=`#fff`
Tramway Line 11: background=`#E2562C`, foreground=`#fff`
Tramway Line 13: background=`#6e491e`, foreground=`#fff`
Transilien Line H: background=`#8c602b`, foreground=`#fff`
Transilien Line J: background=`#d2ce00`, foreground=`#000`
Transilien Line K: background=`#9d9b22`, foreground=`#fff`
Transilien Line L: background=`#ceaacf`, foreground=`#000`
Transilien Line N: background=`#00aa8f`, foreground=`#fff`
Transilien Line P: background=`#f2933d`, foreground=`#000`
Transilien Line R: background=`#f2a4b7`, foreground=`#000`
Transilien Line U: background=`#be0045`, foreground=`#fff`
Bus 20/26/27/70/82/N24/N33/N43: background=`#ea894d`, foreground=`#000`
Bus 21/35/64/93/215/N21/N44/N53: background=`#72be8d`, foreground=`#000`
Bus 22/58/61/66: background=`#008054`, foreground=`#fff`
Bus 24/39/56/94: background=`#ab458a`, foreground=`#fff`
Bus 25/43/60/72/86/N66/N130/N150/N152/N153: background=`#d82230`, foreground=`#fff`
Bus 28/45/47/67/80/N31/N41/N62: background=`#ec97a7`, foreground=`#000`
Bus 29/40/52/54/69/89/325: background=`#87ced0`, foreground=`#000`
Bus 30/76/87/95/359: background=`#572a79`, foreground=`#fff`
Bus 31/42/68/75/83/92/N22/N35/N45/N51/N54/N131/N133: background=`#f9c721`, foreground=`#000`
Bus 32/57: background=`#8e903b`, foreground=`#fff`
Bus 38/48/77/PC: background=`#0063a2`, foreground=`#fff`
Bus 46/63/74/88/N34/N52/N63/N151: background=`#c7c332`, foreground=`#000`
Bus 59/91/96/N23/N32/N42/N61: background=`#d5aa41`, foreground=`#000`
Bus 62/71/73/85/201: background=`#7f5d38`, foreground=`#fff`
Bus 84: background=`#bc9bbd`, foreground=`#000`
Bus 528: background=`#ea9080`, foreground=`#000`
Bus N122/N140/N143: background=`#4d86b8`, foreground=`#fff`
Bus N132/N133/N144/N145: background=`#00995a`, foreground=`#fff`
Bus N141: background=`#f1ac71`, foreground=`#000`
Bus N142: background=`#8d6a8f`, foreground=`#fff`
OrlyBus/RoissyBus: background=`#e3051b`, foreground=`#fff`