### PR TITLE
Resources: New palettes of Kaohsiung

### DIFF
--- a/public/resources/palettes/kaohsiung.json
+++ b/public/resources/palettes/kaohsiung.json
@@ -1,110 +1,131 @@
 [
     {
         "id": "red",
+        "colour": "#e20b65",
+        "fg": "#fff",
         "name": {
             "en": "Red Line",
             "zh-Hans": "红线",
             "zh-Hant": "紅線"
-        },
-        "colour": "#e20b65"
+        }
     },
     {
         "id": "orange",
+        "colour": "#faa73f",
+        "fg": "#fff",
         "name": {
             "en": "Orange Line",
             "zh-Hans": "橘线",
             "zh-Hant": "橘線"
-        },
-        "colour": "#faa73f"
+        }
     },
     {
         "id": "circular",
+        "colour": "#7cbd52",
+        "fg": "#fff",
         "name": {
             "en": "Circular Line (KLRT)",
             "zh-Hans": "环状轻轨",
             "zh-Hant": "環狀輕軌"
-        },
-        "colour": "#7cbd52"
+        }
     },
     {
         "id": "green",
+        "colour": "#50cb00",
+        "fg": "#fff",
         "name": {
             "en": "Green Line",
             "zh-Hans": "绿线",
             "zh-Hant": "綠線"
-        },
-        "colour": "#50cb00"
+        }
     },
     {
         "id": "silver",
+        "colour": "#929292",
+        "fg": "#fff",
         "name": {
             "en": "Silver Line",
             "zh-Hans": "银线",
             "zh-Hant": "銀線"
-        },
-        "colour": "#929292"
+        }
     },
     {
         "id": "blue",
+        "colour": "#007fff",
+        "fg": "#fff",
         "name": {
             "en": "Blue Line",
             "zh-Hans": "蓝线",
             "zh-Hant": "藍線"
-        },
-        "colour": "#007fff"
+        }
     },
     {
         "id": "cyan",
+        "colour": "#00bfff",
+        "fg": "#fff",
         "name": {
             "en": "Cyan Line",
             "zh-Hans": "青线",
             "zh-Hant": "青線"
-        },
-        "colour": "#00bfff"
+        }
     },
     {
         "id": "foguangshan",
+        "colour": "#aa34c0",
+        "fg": "#fff",
         "name": {
             "en": "Foguangshan Line",
             "zh-Hans": "佛光山线",
             "zh-Hant": "佛光山線"
-        },
-        "colour": "#aa34c0"
+        }
     },
     {
         "id": "purple",
+        "colour": "#c100ff",
+        "fg": "#fff",
         "name": {
             "en": "Purple Line",
             "zh-Hans": "紫线",
             "zh-Hant": "紫線"
-        },
-        "colour": "#c100ff"
+        }
     },
     {
         "id": "yh",
+        "colour": "#008583",
+        "fg": "#fff",
         "name": {
             "en": "Youchang Line",
             "zh-Hans": "右昌线",
             "zh-Hant": "右昌線"
-        },
-        "colour": "#008583"
+        }
     },
     {
         "id": "pink",
+        "colour": "#FFC0CB",
+        "fg": "#fff",
         "name": {
             "en": "Pink Line",
             "zh-Hans": "粉红线",
             "zh-Hant": "粉紅線"
-        },
-        "colour": "#FFC0CB"
+        }
     },
     {
         "id": "tra",
+        "colour": "#0008bd",
+        "fg": "#fff",
         "name": {
             "en": "TRA",
             "zh-Hans": "台湾铁路",
             "zh-Hant": "台灣鐵路"
-        },
-        "colour": "#0008bd"
+        }
+    },
+    {
+        "id": "黃線",
+        "colour": "#ffc200",
+        "fg": "#fff",
+        "name": {
+            "zh": "黃線",
+            "en": "Yellow Line"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Kaohsiung on behalf of Benson20110806.
This should fix #485

> @railmapgen/rmg-palette-resources@0.7.7 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Red Line: background=`#e20b65`, foreground=`#fff`
Orange Line: background=`#faa73f`, foreground=`#fff`
Circular Line (KLRT): background=`#7cbd52`, foreground=`#fff`
Green Line: background=`#50cb00`, foreground=`#fff`
Silver Line: background=`#929292`, foreground=`#fff`
Blue Line: background=`#007fff`, foreground=`#fff`
Cyan Line: background=`#00bfff`, foreground=`#fff`
Foguangshan Line: background=`#aa34c0`, foreground=`#fff`
Purple Line: background=`#c100ff`, foreground=`#fff`
Youchang Line: background=`#008583`, foreground=`#fff`
Pink Line: background=`#FFC0CB`, foreground=`#fff`
TRA: background=`#0008bd`, foreground=`#fff`
Yellow Line: background=`#ffc200`, foreground=`#fff`