### PR TITLE
Resources: New palettes of Shijiazhuang

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -850,6 +850,14 @@
         }
     },
     {
+        "id": "shijiazhuang",
+        "country": "CN",
+        "name": {
+            "en": "Shijiazhuang",
+            "zh-Hans": "石家庄"
+        }
+    },
+    {
         "id": "singapore",
         "country": "SG",
         "name": {

--- a/public/resources/palettes/shijiazhuang.json
+++ b/public/resources/palettes/shijiazhuang.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "sjz1",
-        "colour": "#e7212e",
+        "colour": "#e53e30",
         "fg": "#fff",
         "name": {
             "en": "Line 1",
@@ -10,7 +10,7 @@
     },
     {
         "id": "sjz2",
-        "colour": "#f6c600",
+        "colour": "#fec30a",
         "fg": "#fff",
         "name": {
             "en": "Line 2",
@@ -19,38 +19,11 @@
     },
     {
         "id": "sjz3",
-        "colour": "#33bee9",
+        "colour": "#00a1e0",
         "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线"
-        }
-    },
-    {
-        "id": "sjz4",
-        "colour": "#40c1bd",
-        "fg": "#fff",
-        "name": {
-            "en": "Line 4",
-            "zh-Hans": "4号线"
-        }
-    },
-    {
-        "id": "sjz5",
-        "colour": "#ff7e27",
-        "fg": "#fff",
-        "name": {
-            "en": "Line 5",
-            "zh-Hans": "5号线"
-        }
-    },
-    {
-        "id": "sjz6",
-        "colour": "#7030a0",
-        "fg": "#fff",
-        "name": {
-            "en": "Line 6",
-            "zh-Hans": "6号线"
         }
     }
 ]

--- a/public/resources/palettes/shijiazhuang.json
+++ b/public/resources/palettes/shijiazhuang.json
@@ -1,0 +1,56 @@
+[
+    {
+        "id": "sjz1",
+        "colour": "#e7212e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线"
+        }
+    },
+    {
+        "id": "sjz2",
+        "colour": "#f6c600",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线"
+        }
+    },
+    {
+        "id": "sjz3",
+        "colour": "#33bee9",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线"
+        }
+    },
+    {
+        "id": "sjz4",
+        "colour": "#40c1bd",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "zh-Hans": "4号线"
+        }
+    },
+    {
+        "id": "sjz5",
+        "colour": "#ff7e27",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "zh-Hans": "5号线"
+        }
+    },
+    {
+        "id": "sjz6",
+        "colour": "#7030a0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shijiazhuang on behalf of RedLeaf007.
This should fix #489

> @railmapgen/rmg-palette-resources@0.7.7 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=~#e7212e~ `#e53e30`, foreground=`#fff`
Line 2: background=~#f6c600~ `#fec30a`, foreground=`#fff`
Line 3: background=~#33bee9~ `#00a1e0`, foreground=`#fff`
~Line 4: background=#40c1bd, foreground=#fff~
~Line 5: background=#ff7e27, foreground=#fff~
~Line 6: background=#7030a0, foreground=#fff~

---

**Change of April 25, 2:58PM EST:** update all color palette based on following comment:

> wiki现有资料（来源：https://zh.wikipedia.org/wiki/Template:%E7%9F%B3%E5%AE%B6%E5%BA%84%E5%9C%B0%E9%93%81%E9%A2%9C%E8%89%B2 ）
> 1号线 #e53e30
> 2号线 #fec30a
> 3号线 #00a1e0