### PR TITLE
Resources: New palettes of Changsha

### DIFF
--- a/public/resources/palettes/changsha.json
+++ b/public/resources/palettes/changsha.json
@@ -128,5 +128,65 @@
             "zh-Hans": "磁浮快线",
             "zh-Hant": "磁浮快線"
         }
+    },
+    {
+        "id": "cs13",
+        "colour": "#d89fa0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 13",
+            "zh-Hans": "13号线",
+            "zh-Hant": "13號線"
+        }
+    },
+    {
+        "id": "cs14",
+        "colour": "#4f7a28",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 14",
+            "zh-Hans": "14号线",
+            "zh-Hant": "14號線"
+        }
+    },
+    {
+        "id": "cs15",
+        "colour": "#0cbc12",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 15",
+            "zh-Hans": "15号线",
+            "zh-Hant": "15號線"
+        }
+    },
+    {
+        "id": "cs16",
+        "colour": "#b92d5d",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 16",
+            "zh-Hans": "16号线",
+            "zh-Hant": "16號線"
+        }
+    },
+    {
+        "id": "cs17",
+        "colour": "#aaaaaa",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 17",
+            "zh-Hans": "17号线",
+            "zh-Hant": "17號線"
+        }
+    },
+    {
+        "id": "cs18",
+        "colour": "#002e7a",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 18",
+            "zh-Hans": "18号线",
+            "zh-Hant": "18號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Changsha on behalf of Windows-Taskmgr.
This should fix #491

> @railmapgen/rmg-palette-resources@0.7.7 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#DA291C`, foreground=`#fff`
Line 2: background=`#8DC8E8`, foreground=`#fff`
Line 3: background=`#C0DF16`, foreground=`#000`
Line 4: background=`#A51890`, foreground=`#fff`
Line 5: background=`#FFD100`, foreground=`#000`
Line 6: background=`#0077C8`, foreground=`#fff`
Line 7: background=`#009739`, foreground=`#fff`
Line 8: background=`#D9027D`, foreground=`#fff`
Line 9: background=`#00BFB2`, foreground=`#000`
Line 10: background=`#81312F`, foreground=`#fff`
Line 11: background=`#DE7C00`, foreground=`#fff`
Line 12: background=`#9063CD`, foreground=`#fff`
Maglev Express: background=`#F891A5`, foreground=`#fff`
Line 13: background=`#d89fa0`, foreground=`#fff`
Line 14: background=`#4f7a28`, foreground=`#fff`
Line 15: background=`#0cbc12`, foreground=`#fff`
Line 16: background=`#b92d5d`, foreground=`#fff`
Line 17: background=`#aaaaaa`, foreground=`#fff`
Line 18: background=`#002e7a`, foreground=`#fff`