### PR TITLE
Resources: New palettes of Chongqing

### DIFF
--- a/public/resources/palettes/chongqing.json
+++ b/public/resources/palettes/chongqing.json
@@ -190,6 +190,56 @@
         }
     },
     {
+        "id": "cq19",
+        "colour": "#bc204b",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 19",
+            "zh-Hans": "19号线",
+            "zh-Hant": "19號線"
+        }
+    },
+    {
+        "id": "cq20",
+        "colour": "#e31c79",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 20",
+            "zh-Hans": "20号线",
+            "zh-Hant": "20號線"
+        }
+    },
+    {
+        "id": "cq21",
+        "colour": "#007fa3",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 21",
+            "zh-Hans": "21号线",
+            "zh-Hant": "21號線"
+        }
+    },
+    {
+        "id": "cq22",
+        "colour": "#003d4c",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 22",
+            "zh-Hans": "22号线",
+            "zh-Hant": "22號線"
+        }
+    },
+    {
+        "id": "cq23",
+        "colour": "#e35205",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 23",
+            "zh-Hans": "23号线",
+            "zh-Hant": "23號線"
+        }
+    },
+    {
         "id": "cq24",
         "colour": "#00a3ad",
         "fg": "#fff",
@@ -200,6 +250,26 @@
         }
     },
     {
+        "id": "cq25",
+        "colour": "#00685e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 25",
+            "zh-Hans": "25号线",
+            "zh-Hant": "25號線"
+        }
+    },
+    {
+        "id": "cq26",
+        "colour": "#00c389",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 26",
+            "zh-Hans": "26号线",
+            "zh-Hant": "26號線"
+        }
+    },
+    {
         "id": "cq27",
         "colour": "#685bc7",
         "fg": "#fff",
@@ -207,6 +277,16 @@
             "en": "Line 27",
             "zh-Hans": "27号线",
             "zh-Hant": "27號線"
+        }
+    },
+    {
+        "id": "cq28",
+        "colour": "#007398",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 28",
+            "zh-Hans": "28号线",
+            "zh-Hant": "28號線"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Chongqing on behalf of tanxiaoru666.
This should fix #493

> @railmapgen/rmg-palette-resources@0.7.8 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Loop Line: background=`#f2a900`, foreground=`#fff`
Line 1: background=`#E4002B`, foreground=`#fff`
Line 2: background=`#007033`, foreground=`#fff`
Line 3: background=`#003DA5`, foreground=`#fff`
Line 4: background=`#DC8633`, foreground=`#fff`
Line 5: background=`#00A3E0`, foreground=`#fff`
Line 6: background=`#F67599`, foreground=`#fff`
Line 7: background=`#008C95`, foreground=`#fff`
Line 8: background=`#7A9A01`, foreground=`#fff`
Line 9: background=`#861f41`, foreground=`#fff`
Line 10: background=`#5f259f`, foreground=`#fff`
Line 11: background=`#D986BA`, foreground=`#fff`
Line 12: background=`#D2D755`, foreground=`#fff`
Line 13: background=`#B89D18`, foreground=`#fff`
Line 14: background=`#B94700`, foreground=`#fff`
Line 15: background=`#0057b8`, foreground=`#fff`
Line 16: background=`#B04A5A`, foreground=`#fff`
Line 17: background=`#9F5CC0`, foreground=`#fff`
Line 18: background=`#2ad2c9`, foreground=`#fff`
Line 19: background=`#bc204b`, foreground=`#fff`
Line 20: background=`#e31c79`, foreground=`#fff`
Line 21: background=`#007fa3`, foreground=`#fff`
Line 22: background=`#003d4c`, foreground=`#fff`
Line 23: background=`#e35205`, foreground=`#fff`
Line 24: background=`#00a3ad`, foreground=`#fff`
Line 25: background=`#00685e`, foreground=`#fff`
Line 26: background=`#00c389`, foreground=`#fff`
Line 27: background=`#685bc7`, foreground=`#fff`
Line 28: background=`#007398`, foreground=`#fff`
Jiangtiao Line: background=`#0077c8`, foreground=`#fff`