### PR TITLE
*Vandalism Content*

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -758,6 +758,14 @@
         }
     },
     {
+        "id": "rongcheng",
+        "country": "CN",
+        "name": {
+            "zh-Hans": "荣城",
+            "en": "Rongcheng"
+        }
+    },
+    {
         "id": "sanfrancisco",
         "country": "US",
         "name": {

--- a/public/resources/palettes/rongcheng.json
+++ b/public/resources/palettes/rongcheng.json
@@ -1,0 +1,146 @@
+[
+    {
+        "id": "rc1",
+        "colour": "#df1616",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线"
+        }
+    },
+    {
+        "id": "rc2",
+        "colour": "#12ce31",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线"
+        }
+    },
+    {
+        "id": "rc3",
+        "colour": "#1695d4",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线"
+        }
+    },
+    {
+        "id": "rc4",
+        "colour": "#d411d4",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "zh-Hans": "4号线"
+        }
+    },
+    {
+        "id": "rc5",
+        "colour": "#ff9900",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "zh-Hans": "5号线"
+        }
+    },
+    {
+        "id": "rc6",
+        "colour": "#f09ed6",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线"
+        }
+    },
+    {
+        "id": "rc7",
+        "colour": "#11d4a4",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 7",
+            "zh-Hans": "7号线"
+        }
+    },
+    {
+        "id": "rc8",
+        "colour": "#c2c2c2",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh-Hans": "8号线"
+        }
+    },
+    {
+        "id": "rc9",
+        "colour": "#9c7126",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 9",
+            "zh-Hans": "9号线"
+        }
+    },
+    {
+        "id": "rcS1",
+        "colour": "#d411d4",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh-Hans": "S1号线"
+        }
+    },
+    {
+        "id": "rcS2",
+        "colour": "#5d10d1",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S2",
+            "zh-Hans": "S2号线"
+        }
+    },
+    {
+        "id": "rcT1",
+        "colour": "#3d8038",
+        "fg": "#fff",
+        "name": {
+            "en": "Line T1",
+            "zh-Hans": "T1号线"
+        }
+    },
+    {
+        "id": "rcT2",
+        "colour": "#386e80",
+        "fg": "#fff",
+        "name": {
+            "en": "Line T2",
+            "zh-Hans": "T2号线"
+        }
+    },
+    {
+        "id": "rcT3",
+        "colour": "#6d3880",
+        "fg": "#fff",
+        "name": {
+            "en": "Line T3",
+            "zh-Hans": "T3号线"
+        }
+    },
+    {
+        "id": "rcM1",
+        "colour": "#d7d11d",
+        "fg": "#fff",
+        "name": {
+            "en": "Line M1",
+            "zh-Hans": "M1号线"
+        }
+    },
+    {
+        "id": "rcAP",
+        "colour": "#8593ff",
+        "fg": "#fff",
+        "name": {
+            "en": "Line Airport",
+            "zh-Hans": "机场线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating *Vandalism Content* on behalf of LewisHamilton44L.
This should fix #495

> @railmapgen/rmg-palette-resources@0.7.8 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: background=`#df1616`, foreground=`#fff`
Line 2: background=`#12ce31`, foreground=`#fff`
Line 3: background=`#1695d4`, foreground=`#fff`
Line 4: background=`#d411d4`, foreground=`#fff`
Line 5: background=`#ff9900`, foreground=`#fff`
Line 6: background=`#f09ed6`, foreground=`#fff`
Line 7: background=`#11d4a4`, foreground=`#fff`
Line 8: background=`#c2c2c2`, foreground=`#fff`
Line 9: background=`#9c7126`, foreground=`#fff`
Line S1: background=`#d411d4`, foreground=`#fff`
Line S2: background=`#5d10d1`, foreground=`#fff`
Line T1: background=`#3d8038`, foreground=`#fff`
Line T2: background=`#386e80`, foreground=`#fff`
Line T3: background=`#6d3880`, foreground=`#fff`
Line M1: background=`#d7d11d`, foreground=`#fff`
Line Airport: background=`#8593ff`, foreground=`#fff`