### PR TITLE
Resources: New palettes of Dublin

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -256,6 +256,13 @@
         }
     },
     {
+        "id": "dublin",
+        "country": "IE",
+        "name": {
+            "en": "Dublin"
+        }
+    },
+    {
         "id": "edinburgh",
         "country": "GBSCT",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -191,6 +191,13 @@
         "language": "id"
     },
     {
+        "id": "IE",
+        "name": {
+            "en": "Ireland"
+        },
+        "language": "ga"
+    },
+    {
         "id": "IN",
         "name": {
             "en": "India",

--- a/public/resources/palettes/dublin.json
+++ b/public/resources/palettes/dublin.json
@@ -1,0 +1,10 @@
+[
+    {
+        "id": "l1",
+        "colour": "#aaaaaa",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Dublin on behalf of wongchito.
This should fix #508

> @railmapgen/rmg-palette-resources@0.7.8 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#aaaaaa`, fg=`#fff`