### PR TITLE
Resources: New palettes of Dublin

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -256,6 +256,16 @@
         }
     },
     {
+        "id": "dublin",
+        "country": "Ireland",
+        "name": {
+            "en": "Dublin",
+            "ga": "Baile Átha Cliath",
+            "zh-Hans": "都柏林",
+            "zh-Hant": "都柏林"
+        }
+    },
+    {
         "id": "edinburgh",
         "country": "GBSCT",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -209,6 +209,16 @@
         "language": "fa"
     },
     {
+        "id": "Ireland",
+        "name": {
+            "en": "Ireland",
+            "ga": "Éire",
+            "zh-Hans": "爱尔兰",
+            "zh-Hant": "愛爾蘭"
+        },
+        "language": "ga"
+    },
+    {
         "id": "IT",
         "name": {
             "en": "Italy",

--- a/public/resources/palettes/dublin.json
+++ b/public/resources/palettes/dublin.json
@@ -1,0 +1,66 @@
+[
+    {
+        "id": "dart",
+        "colour": "#029641",
+        "fg": "#fff",
+        "name": {
+            "en": "DART Train"
+        }
+    },
+    {
+        "id": "red",
+        "colour": "#e30813",
+        "fg": "#fff",
+        "name": {
+            "en": "Luas Red Line Tram"
+        }
+    },
+    {
+        "id": "green",
+        "colour": "#86bd4c",
+        "fg": "#fff",
+        "name": {
+            "en": "Luas Green Line Tram"
+        }
+    },
+    {
+        "id": "aircoach",
+        "colour": "#847ab8",
+        "fg": "#fff",
+        "name": {
+            "en": "Aircoach Bus 700"
+        }
+    },
+    {
+        "id": "northern",
+        "colour": "#e56da4",
+        "fg": "#fff",
+        "name": {
+            "en": "Northern Commuter Train"
+        }
+    },
+    {
+        "id": "southwestern",
+        "colour": "#fec502",
+        "fg": "#fff",
+        "name": {
+            "en": "Southwestern Commuter Train"
+        }
+    },
+    {
+        "id": "western",
+        "colour": "#2b3089",
+        "fg": "#fff",
+        "name": {
+            "en": "Western Commuter Train"
+        }
+    },
+    {
+        "id": "southeastern",
+        "colour": "#f69e02",
+        "fg": "#fff",
+        "name": {
+            "en": "Southeastern Commuter Train"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Dublin on behalf of wongchito.
This should fix #511

> @railmapgen/rmg-palette-resources@0.7.9 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

DART Train: bg=`#029641`, fg=`#fff`
Luas Red Line Tram: bg=`#e30813`, fg=`#fff`
Luas Green Line Tram: bg=`#86bd4c`, fg=`#fff`
Aircoach Bus 700: bg=`#847ab8`, fg=`#fff`
Northern Commuter Train: bg=`#e56da4`, fg=`#fff`
Southwestern Commuter Train: bg=`#fec502`, fg=`#fff`
Western Commuter Train: bg=`#2b3089`, fg=`#fff`
Southeastern Commuter Train: bg=`#f69e02`, fg=`#fff`