### PR TITLE
Resources: New palettes of Amsterdam

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1,5 +1,14 @@
 [
     {
+        "id": "amsterdam",
+        "country": "NL",
+        "name": {
+            "en": "Amsterdam",
+            "ko": "암스테르담",
+            "zh": "阿姆斯特丹"
+        }
+    },
+    {
         "id": "ankara",
         "country": "TR",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -278,6 +278,15 @@
         "language": "ms"
     },
     {
+        "id": "NL",
+        "name": {
+            "en": "Netherlands",
+            "ko": "네덜란드",
+            "zh-Hans": "荷兰",
+            "zh-Hant": "荷蘭"
+        }
+    },
+    {
         "id": "NO",
         "name": {
             "en": "Norway",

--- a/public/resources/palettes/amsterdam.json
+++ b/public/resources/palettes/amsterdam.json
@@ -1,0 +1,310 @@
+[
+    {
+        "id": "m50",
+        "colour": "#00984a",
+        "fg": "#fff",
+        "name": {
+            "en": "M50",
+            "ko": "M50",
+            "zh-Hans": "M50",
+            "zh-Hant": "M50"
+        }
+    },
+    {
+        "id": "m51",
+        "colour": "#f68b1f",
+        "fg": "#fff",
+        "name": {
+            "en": "M51",
+            "ko": "M51",
+            "zh-Hans": "M51",
+            "zh-Hant": "M51"
+        }
+    },
+    {
+        "id": "m52",
+        "colour": "#0696d7",
+        "fg": "#fff",
+        "name": {
+            "en": "M52",
+            "ko": "M52",
+            "zh-Hans": "M52",
+            "zh-Hant": "M52"
+        }
+    },
+    {
+        "id": "m53",
+        "colour": "#ee1d23",
+        "fg": "#fff",
+        "name": {
+            "en": "M53",
+            "ko": "M53",
+            "zh-Hans": "M53",
+            "zh-Hant": "M53"
+        }
+    },
+    {
+        "id": "m54",
+        "colour": "#fed304",
+        "fg": "#000",
+        "name": {
+            "en": "M54",
+            "ko": "M54",
+            "zh-Hans": "M54",
+            "zh-Hant": "M54"
+        }
+    },
+    {
+        "id": "t1",
+        "colour": "#f05937",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 1",
+            "ko": "트램 1",
+            "zh-Hans": "1路电车",
+            "zh-Hant": "1路電車"
+        }
+    },
+    {
+        "id": "t2",
+        "colour": "#3ab54a",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 2",
+            "ko": "트램 2",
+            "zh-Hans": "2路电车",
+            "zh-Hant": "2路電車"
+        }
+    },
+    {
+        "id": "t3",
+        "colour": "#9a94c8",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 3",
+            "ko": "트램 3",
+            "zh-Hans": "3路电车",
+            "zh-Hant": "3路電車"
+        }
+    },
+    {
+        "id": "t4",
+        "colour": "#f171ab",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 4",
+            "ko": "트램 4",
+            "zh-Hans": "4路电车",
+            "zh-Hant": "4路電車"
+        }
+    },
+    {
+        "id": "t5",
+        "colour": "#756fb3",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 5",
+            "ko": "트램 5",
+            "zh-Hans": "5路电车",
+            "zh-Hant": "5路電車"
+        }
+    },
+    {
+        "id": "t7",
+        "colour": "#f69672",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 7",
+            "ko": "트램 7",
+            "zh-Hans": "7路电车",
+            "zh-Hant": "7路電車"
+        }
+    },
+    {
+        "id": "t12",
+        "colour": "#008f4d",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 12",
+            "ko": "트램 12",
+            "zh-Hans": "12路电车",
+            "zh-Hant": "12路電車"
+        }
+    },
+    {
+        "id": "t13",
+        "colour": "#a6ce39",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 13",
+            "ko": "트램 13",
+            "zh-Hans": "13路电车",
+            "zh-Hant": "13路電車"
+        }
+    },
+    {
+        "id": "t14",
+        "colour": "#ed1e91",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 14",
+            "ko": "트램 14",
+            "zh-Hans": "14路电车",
+            "zh-Hant": "14路電車"
+        }
+    },
+    {
+        "id": "t17",
+        "colour": "#7fc241",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 17",
+            "ko": "트램 17",
+            "zh-Hans": "17路电车",
+            "zh-Hant": "17路電車"
+        }
+    },
+    {
+        "id": "t19",
+        "colour": "#f36f4a",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 19",
+            "ko": "트램 19",
+            "zh-Hans": "19路电车",
+            "zh-Hant": "19路電車"
+        }
+    },
+    {
+        "id": "t24",
+        "colour": "#f499c2",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 24",
+            "ko": "트램 24",
+            "zh-Hans": "24路电车",
+            "zh-Hant": "24路電車"
+        }
+    },
+    {
+        "id": "t25",
+        "colour": "#ee1d23",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 25",
+            "ko": "트램 25",
+            "zh-Hans": "25路电车",
+            "zh-Hant": "25路電車"
+        }
+    },
+    {
+        "id": "t26",
+        "colour": "#625ea9",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 26",
+            "ko": "트램 26",
+            "zh-Hans": "26路电车",
+            "zh-Hant": "26路電車"
+        }
+    },
+    {
+        "id": "t27",
+        "colour": "#00ae9d",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 27",
+            "ko": "트램 27",
+            "zh-Hans": "27路电车",
+            "zh-Hant": "27路電車"
+        }
+    },
+    {
+        "id": "f1",
+        "colour": "#0f6ab2",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 1",
+            "ko": "페리 노선 1",
+            "zh-Hans": "轮渡1号线",
+            "zh-Hant": "輪渡1號線"
+        }
+    },
+    {
+        "id": "f2",
+        "colour": "#2b9cd8",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 2",
+            "ko": "페리 노선 2",
+            "zh-Hans": "轮渡2号线",
+            "zh-Hant": "輪渡2號線"
+        }
+    },
+    {
+        "id": "f3",
+        "colour": "#239e38",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 3",
+            "ko": "페리 노선 3",
+            "zh-Hans": "轮渡3号线",
+            "zh-Hant": "輪渡3號線"
+        }
+    },
+    {
+        "id": "f4",
+        "colour": "#9b4490",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 4",
+            "ko": "페리 노선 4",
+            "zh-Hans": "轮渡4号线",
+            "zh-Hant": "輪渡4號線"
+        }
+    },
+    {
+        "id": "f5",
+        "colour": "#2b2523",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 5",
+            "ko": "페리 노선 5",
+            "zh-Hans": "轮渡5号线",
+            "zh-Hant": "輪渡5號線"
+        }
+    },
+    {
+        "id": "f6",
+        "colour": "#dc0c15",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 6",
+            "ko": "페리 노선 6",
+            "zh-Hans": "轮渡6号线",
+            "zh-Hant": "輪渡6號線"
+        }
+    },
+    {
+        "id": "f7",
+        "colour": "#f09100",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 7",
+            "ko": "페리 노선 7",
+            "zh-Hans": "轮渡7号线",
+            "zh-Hant": "輪渡7號線"
+        }
+    },
+    {
+        "id": "f9",
+        "colour": "#e6007d",
+        "fg": "#fff",
+        "name": {
+            "en": "Ferry Line 9",
+            "ko": "페리 노선 9",
+            "zh-Hans": "轮渡9号线",
+            "zh-Hant": "輪渡9號線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Amsterdam on behalf of linchen1965.
This should fix #513

> @railmapgen/rmg-palette-resources@0.7.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

M50: bg=`#00984a`, fg=`#fff`
M51: bg=`#f68b1f`, fg=`#fff`
M52: bg=`#0696d7`, fg=`#fff`
M53: bg=`#ee1d23`, fg=`#fff`
M54: bg=`#fed304`, fg=`#000`
Tram 1: bg=`#f05937`, fg=`#fff`
Tram 2: bg=`#3ab54a`, fg=`#fff`
Tram 3: bg=`#9a94c8`, fg=`#fff`
Tram 4: bg=`#f171ab`, fg=`#fff`
Tram 5: bg=`#756fb3`, fg=`#fff`
Tram 7: bg=`#f69672`, fg=`#fff`
Tram 12: bg=`#008f4d`, fg=`#fff`
Tram 13: bg=`#a6ce39`, fg=`#fff`
Tram 14: bg=`#ed1e91`, fg=`#fff`
Tram 17: bg=`#7fc241`, fg=`#fff`
Tram 19: bg=`#f36f4a`, fg=`#fff`
Tram 24: bg=`#f499c2`, fg=`#fff`
Tram 25: bg=`#ee1d23`, fg=`#fff`
Tram 26: bg=`#625ea9`, fg=`#fff`
Tram 27: bg=`#00ae9d`, fg=`#fff`
Ferry Line 1: bg=`#0f6ab2`, fg=`#fff`
Ferry Line 2: bg=`#2b9cd8`, fg=`#fff`
Ferry Line 3: bg=`#239e38`, fg=`#fff`
Ferry Line 4: bg=`#9b4490`, fg=`#fff`
Ferry Line 5: bg=`#2b2523`, fg=`#fff`
Ferry Line 6: bg=`#dc0c15`, fg=`#fff`
Ferry Line 7: bg=`#f09100`, fg=`#fff`
Ferry Line 9: bg=`#e6007d`, fg=`#fff`