### PR TITLE
Resources: New palettes of Changzhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -177,6 +177,16 @@
         }
     },
     {
+        "id": "changzhou",
+        "country": "CN",
+        "name": {
+            "en": "Changzhou",
+            "ko": "창저우",
+            "zh-Hans": "常州",
+            "zh-Hant": "常州"
+        }
+    },
+    {
         "id": "chengdu",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/changzhou.json
+++ b/public/resources/palettes/changzhou.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "cz1",
+        "colour": "#bf635f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "ko": "1호선",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線"
+        }
+    },
+    {
+        "id": "cz2",
+        "colour": "#659dc5",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "ko": "2호선",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線"
+        }
+    }
+]

--- a/public/resources/palettes/changzhou.json
+++ b/public/resources/palettes/changzhou.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "cz1",
-        "colour": "#bf635f",
+        "colour": "#cd5c5c",
         "fg": "#fff",
         "name": {
             "en": "Line 1",
@@ -12,7 +12,7 @@
     },
     {
         "id": "cz2",
-        "colour": "#659dc5",
+        "colour": "#529fc9",
         "fg": "#fff",
         "name": {
             "en": "Line 2",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Changzhou on behalf of 28yfang.
This should fix #516

> @railmapgen/rmg-palette-resources@0.7.11 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#bf635f`, fg=`#fff`
Line 2: bg=`#659dc5`, fg=`#fff`