### PR TITLE
Resources: New palettes of Nanchang

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -639,6 +639,16 @@
         }
     },
     {
+        "id": "nanchang",
+        "country": "CN",
+        "name": {
+            "en": "Nanchang",
+            "ko": "난창",
+            "zh-Hans": "南昌",
+            "zh-Hant": "南昌"
+        }
+    },
+    {
         "id": "nanjing",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/nanchang.json
+++ b/public/resources/palettes/nanchang.json
@@ -1,0 +1,57 @@
+[
+    {
+        "id": "nc1",
+        "colour": "#e60039",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "ko": "1호선",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線"
+        }
+    },
+    {
+        "id": "nc2",
+        "colour": "#ffda01",
+        "fg": "#000",
+        "name": {
+            "en": "Line 2",
+            "ko": "2호선",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線"
+        }
+    },
+    {
+        "id": "nc3",
+        "colour": "#0079c3",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "ko": "3호선",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線"
+        }
+    },
+    {
+        "id": "nc4",
+        "colour": "#00a560",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "ko": "4호선",
+            "zh-Hans": "4号线",
+            "zh-Hant": "4號線"
+        }
+    },
+    {
+        "id": "nc5",
+        "colour": "#f0831e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "ko": "5호선",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanchang on behalf of 28yfang.
This should fix #522

> @railmapgen/rmg-palette-resources@0.7.14 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#e60039`, fg=`#fff`
Line 2: bg=`#ffda01`, fg=`#000`
Line 3: bg=`#0079c3`, fg=`#fff`
Line 4: bg=`#00a560`, fg=`#fff`
Line 5: bg=`#f0831e`, fg=`#fff`