### PR TITLE
Resources: New palettes of Rotterdam

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -797,6 +797,15 @@
         }
     },
     {
+        "id": "rotterdam",
+        "country": "NL",
+        "name": {
+            "en": "Rotterdam",
+            "ko": "로테르담",
+            "zh": "鹿特丹"
+        }
+    },
+    {
         "id": "sanfrancisco",
         "country": "US",
         "name": {

--- a/public/resources/palettes/rotterdam.json
+++ b/public/resources/palettes/rotterdam.json
@@ -1,0 +1,52 @@
+[
+    {
+        "id": "ra",
+        "colour": "#009e50",
+        "fg": "#fff",
+        "name": {
+            "en": "Line A",
+            "zh-Hans": "A线",
+            "zh-Hant": "A缐"
+        }
+    },
+    {
+        "id": "rb",
+        "colour": "#fecc26",
+        "fg": "#000",
+        "name": {
+            "en": "Line B",
+            "zh-Hans": "B线",
+            "zh-Hant": "B缐"
+        }
+    },
+    {
+        "id": "rc",
+        "colour": "#e3322f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line C",
+            "zh-Hans": "C线",
+            "zh-Hant": "C缐"
+        }
+    },
+    {
+        "id": "rd",
+        "colour": "#52c4e9",
+        "fg": "#fff",
+        "name": {
+            "en": "Line D",
+            "zh-Hans": "D线",
+            "zh-Hant": "D缐"
+        }
+    },
+    {
+        "id": "re",
+        "colour": "#213b71",
+        "fg": "#fff",
+        "name": {
+            "en": "Line E",
+            "zh-Hans": "E线",
+            "zh-Hant": "E缐"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Rotterdam on behalf of linchen1965.
This should fix #524

> @railmapgen/rmg-palette-resources@0.7.14 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line A: bg=`#009e50`, fg=`#fff`
Line B: bg=`#fecc26`, fg=`#000`
Line C: bg=`#e3322f`, fg=`#fff`
Line D: bg=`#52c4e9`, fg=`#fff`
Line E: bg=`#213b71`, fg=`#fff`