### PR TITLE
Resources: New palettes of Shenyang

### DIFF
--- a/public/resources/palettes/shenyang.json
+++ b/public/resources/palettes/shenyang.json
@@ -1,65 +1,72 @@
 [
     {
         "id": "sy1",
+        "colour": "#b63f1f",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#FE0000"
+        }
     },
     {
         "id": "sy2",
+        "colour": "#e5703a",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#EE782E"
+        }
     },
     {
         "id": "sy3",
+        "colour": "#E6669F",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#E6669F"
+        }
     },
     {
         "id": "sy4",
+        "colour": "#6E3E94",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#6E3E94"
+        }
     },
     {
         "id": "sy6",
+        "colour": "#FEDC00",
+        "fg": "#fff",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
             "zh-Hant": "6號線"
-        },
-        "colour": "#FEDC00"
+        }
     },
     {
         "id": "sy9",
+        "colour": "#017cbf",
+        "fg": "#fff",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
             "zh-Hant": "9號線"
-        },
-        "colour": "#018CD1"
+        }
     },
     {
         "id": "sy10",
+        "colour": "#62aa3c",
+        "fg": "#fff",
         "name": {
             "en": "Line 10",
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
-        },
-        "colour": "#81B72E"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenyang on behalf of langonginc.
This should fix #528

> @railmapgen/rmg-palette-resources@0.7.16 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#b63f1f`, fg=`#fff`
Line 2: bg=`#e5703a`, fg=`#fff`
Line 3: bg=`#E6669F`, fg=`#fff`
Line 4: bg=`#6E3E94`, fg=`#fff`
Line 6: bg=`#FEDC00`, fg=`#fff`
Line 9: bg=`#017cbf`, fg=`#fff`
Line 10: bg=`#62aa3c`, fg=`#fff`