### PR TITLE
Resources: New palettes of Nice

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -703,6 +703,14 @@
         }
     },
     {
+        "id": "nice",
+        "country": "FR",
+        "name": {
+            "en": "Nice",
+            "zh": "尼斯"
+        }
+    },
+    {
         "id": "ningbo",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/nice.json
+++ b/public/resources/palettes/nice.json
@@ -1,0 +1,35 @@
+[
+    {
+        "id": "n1",
+        "colour": "#d7171f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號缐",
+            "fr": "Ligne 1"
+        }
+    },
+    {
+        "id": "n2",
+        "colour": "#1074bc",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號缐",
+            "fr": "Ligne 2"
+        }
+    },
+    {
+        "id": "n3",
+        "colour": "#00a54f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號缐",
+            "fr": "Ligne 3"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nice on behalf of linchen1965.
This should fix #530

> @railmapgen/rmg-palette-resources@0.7.16 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#d7171f`, fg=`#fff`
Line 2: bg=`#1074bc`, fg=`#fff`
Line 3: bg=`#00a54f`, fg=`#fff`