### PR TITLE
Resources: New palettes of Lyon

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -572,6 +572,14 @@
         }
     },
     {
+        "id": "lyon",
+        "country": "FR",
+        "name": {
+            "en": "Lyon",
+            "zh": "里昂"
+        }
+    },
+    {
         "id": "macao",
         "country": "MO",
         "name": {

--- a/public/resources/palettes/lyon.json
+++ b/public/resources/palettes/lyon.json
@@ -1,0 +1,68 @@
+[
+    {
+        "id": "na",
+        "colour": "#ea4498",
+        "fg": "#fff",
+        "name": {
+            "en": "Line A",
+            "zh-Hans": "A线",
+            "zh-Hant": "A缐",
+            "fr": "Ligne A"
+        }
+    },
+    {
+        "id": "nb",
+        "colour": "#0077c0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line B",
+            "zh-Hans": "B线",
+            "zh-Hant": "B缐",
+            "fr": "Ligne B"
+        }
+    },
+    {
+        "id": "nc",
+        "colour": "#f79727",
+        "fg": "#fff",
+        "name": {
+            "en": "Line C",
+            "zh-Hans": "C线",
+            "zh-Hant": "C缐",
+            "fr": "Ligne C"
+        }
+    },
+    {
+        "id": "nd",
+        "colour": "#00a94e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line D",
+            "zh-Hans": "D线",
+            "zh-Hant": "D缐",
+            "fr": "Ligne D"
+        }
+    },
+    {
+        "id": "nf",
+        "colour": "#89c650",
+        "fg": "#fff",
+        "name": {
+            "en": "Funicular",
+            "zh-Hans": "缆​索​铁路",
+            "zh-Hant": "纜​索​鐵路",
+            "fr": "Fu­ni­cu­laire"
+        }
+    },
+    {
+        "id": "nt",
+        "colour": "#873e97",
+        "fg": "#fff",
+        "name": {
+            "en": "Tramway",
+            "zh-Hans": "有轨​电车",
+            "zh-Hant": "有軌​電車",
+            "fr": "Tramway"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Lyon on behalf of linchen1965.
This should fix #532

> @railmapgen/rmg-palette-resources@0.7.16 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line A: bg=`#ea4498`, fg=`#fff`
Line B: bg=`#0077c0`, fg=`#fff`
Line C: bg=`#f79727`, fg=`#fff`
Line D: bg=`#00a94e`, fg=`#fff`
Funicular: bg=`#89c650`, fg=`#fff`
Tramway: bg=`#873e97`, fg=`#fff`