### PR TITLE
Resources: New palettes of Hohhot

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -435,6 +435,16 @@
         }
     },
     {
+        "id": "hohhot",
+        "country": "CN",
+        "name": {
+            "en": "Hohhot",
+            "ko": "후허하오터",
+            "zh-Hans": "呼和浩特",
+            "zh-Hant": "呼和浩特"
+        }
+    },
+    {
         "id": "hongkong",
         "country": "HK",
         "name": {

--- a/public/resources/palettes/hohhot.json
+++ b/public/resources/palettes/hohhot.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "hhht1",
+        "colour": "#e82311",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "ko": "1호선",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線"
+        }
+    },
+    {
+        "id": "hhht2",
+        "colour": "#005bac",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "ko": "2호선",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Hohhot on behalf of 28yfang.
This should fix #534

> @railmapgen/rmg-palette-resources@0.7.17 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#e82311`, fg=`#fff`
Line 2: bg=`#005bac`, fg=`#fff`