### PR TITLE
Resources: New palettes of Sydney

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -753,6 +753,15 @@
         }
     },
     {
+        "id": "new",
+        "country": "AU",
+        "name": {
+            "en": "Sydney",
+            "zh-Hans": "悉尼",
+            "zh-Hant": "雪梨"
+        }
+    },
+    {
         "id": "neworleans",
         "country": "US",
         "name": {

--- a/public/resources/palettes/new.json
+++ b/public/resources/palettes/new.json
@@ -1,0 +1,402 @@
+[
+    {
+        "id": "syd1",
+        "colour": "#f99d1c",
+        "fg": "#fff",
+        "name": {
+            "en": "T1 - North Shore & Western Line",
+            "zh-Hans": "T1 - 北海滩与西部线",
+            "zh-Hant": "T1 - 北岸及西線"
+        }
+    },
+    {
+        "id": "syd2",
+        "colour": "#0098cd",
+        "fg": "#fff",
+        "name": {
+            "en": "T2 - Inner West & Leppington Line",
+            "zh-Hans": "T2 - 中西部与雷平顿线",
+            "zh-Hant": "T2 - 中西部與雷平頓線"
+        }
+    },
+    {
+        "id": "syd3",
+        "colour": "#f37021",
+        "fg": "#fff",
+        "name": {
+            "en": "T3 - Bankstown Line",
+            "zh-Hans": "T3 - 班克斯顿线",
+            "zh-Hant": "T3 - 班克斯敦線"
+        }
+    },
+    {
+        "id": "syd4",
+        "colour": "#005aa3",
+        "fg": "#fff",
+        "name": {
+            "en": "T4 - Eastern Suburbs & Illawarra Line",
+            "zh-Hans": "T4 - 东郊与伊拉瓦拉线",
+            "zh-Hant": "T4 - 東郊和伊拉瓦拉線"
+        }
+    },
+    {
+        "id": "syd5",
+        "colour": "#c4258f",
+        "fg": "#fff",
+        "name": {
+            "en": "T5 - Cumberland Line",
+            "zh-Hans": "T5 - 坎伯兰线",
+            "zh-Hant": "T5 - 坎伯蘭線"
+        }
+    },
+    {
+        "id": "syd7",
+        "colour": "#6f818e",
+        "fg": "#fff",
+        "name": {
+            "en": "T7 - Olympic Park Line",
+            "zh-Hans": "T7 - 奥林匹克公园线",
+            "zh-Hant": "T7 - 奧林匹克公園線"
+        }
+    },
+    {
+        "id": "syd8",
+        "colour": "#00954c",
+        "fg": "#fff",
+        "name": {
+            "en": "T8 - Airport & South Line",
+            "zh-Hans": "T8 - 机场与南部线",
+            "zh-Hant": "T8 - 機場南線"
+        }
+    },
+    {
+        "id": "syd9",
+        "colour": "#d11f2f",
+        "fg": "#fff",
+        "name": {
+            "en": "T9 - Northern Line test",
+            "zh-Hans": "T9 - 北部线（测试中）",
+            "zh-Hant": "T9 - 北線測試"
+        }
+    },
+    {
+        "id": "sydm",
+        "colour": "#168388",
+        "fg": "#fff",
+        "name": {
+            "en": "Metro North West Line",
+            "zh-Hans": "地铁西北线",
+            "zh-Hant": "地鐵西北線"
+        }
+    },
+    {
+        "id": "bmt",
+        "colour": "#f99d1c",
+        "fg": "#fff",
+        "name": {
+            "en": "Blue Mountains Line",
+            "zh-Hans": "蓝山线",
+            "zh-Hant": "藍山線"
+        }
+    },
+    {
+        "id": "ccn",
+        "colour": "#d11f2f",
+        "fg": "#fff",
+        "name": {
+            "en": "Central Cost & Newcastle Line",
+            "zh-Hans": "中部海岸与纽卡斯尔线",
+            "zh-Hant": "中央海岸和紐卡斯爾線"
+        }
+    },
+    {
+        "id": "hun",
+        "colour": "#833134",
+        "fg": "#fff",
+        "name": {
+            "en": "Hunter Line",
+            "zh-Hans": "亨特线",
+            "zh-Hant": "亨特線"
+        }
+    },
+    {
+        "id": "sco",
+        "colour": "#005aa3",
+        "fg": "#fff",
+        "name": {
+            "en": "South Coast Line",
+            "zh-Hans": "南部海岸线",
+            "zh-Hant": "南海岸線"
+        }
+    },
+    {
+        "id": "shl",
+        "colour": "#00954c",
+        "fg": "#fff",
+        "name": {
+            "en": "Southern Highlands Line",
+            "zh-Hans": "南部高地线",
+            "zh-Hant": "南部高地線"
+        }
+    },
+    {
+        "id": "syf1",
+        "colour": "#00774b",
+        "fg": "#fff",
+        "name": {
+            "en": "F1 - Manly",
+            "zh-Hans": "F1 - 曼利轮渡",
+            "zh-Hant": "F1 - 曼利輪渡"
+        }
+    },
+    {
+        "id": "syf2",
+        "colour": "#144734",
+        "fg": "#fff",
+        "name": {
+            "en": "F2 - Taronga Zoo",
+            "zh-Hans": "F2 - 塔隆加动物园轮渡",
+            "zh-Hant": "F2 - 塔隆加動物園輪渡"
+        }
+    },
+    {
+        "id": "syf3",
+        "colour": "#648c3c",
+        "fg": "#fff",
+        "name": {
+            "en": "F3 - Parramatta River",
+            "zh-Hans": "F3 - 帕拉玛塔河轮渡",
+            "zh-Hant": "F3 - 帕拉瑪塔河輪渡"
+        }
+    },
+    {
+        "id": "syf4",
+        "colour": "#bfd730",
+        "fg": "#fff",
+        "name": {
+            "en": "F4 - Pyrmont Bay",
+            "zh-Hans": "F4 - 派尔蒙特湾轮渡",
+            "zh-Hant": "F4 - 派爾蒙特灣輪渡"
+        }
+    },
+    {
+        "id": "syf5",
+        "colour": "#286142",
+        "fg": "#fff",
+        "name": {
+            "en": "F5 - Neutral Bay",
+            "zh-Hans": "F5 - 纽图尔湾轮渡",
+            "zh-Hant": "F5 - 紐圖爾灣輪渡"
+        }
+    },
+    {
+        "id": "syf6",
+        "colour": "#00ab51",
+        "fg": "#fff",
+        "name": {
+            "en": "F6 - Mosman Bay",
+            "zh-Hans": "F6 - 莫斯曼湾轮渡",
+            "zh-Hant": "F6 - 莫斯曼灣輪渡"
+        }
+    },
+    {
+        "id": "syf7",
+        "colour": "#00b189",
+        "fg": "#fff",
+        "name": {
+            "en": "F7 - Double Bay",
+            "zh-Hans": "F7 - 双湾轮渡",
+            "zh-Hant": "F7 - 雙灣輪渡"
+        }
+    },
+    {
+        "id": "syf8",
+        "colour": "#55622b",
+        "fg": "#fff",
+        "name": {
+            "en": "F8 - Cockatoo Island",
+            "zh-Hans": "F8 - 凤头鹦鹉岛轮渡",
+            "zh-Hant": "F8 - 鳳頭鸚鵡島輪渡"
+        }
+    },
+    {
+        "id": "syf9",
+        "colour": "#65b32e",
+        "fg": "#fff",
+        "name": {
+            "en": "F9 - Watsons Bay",
+            "zh-Hans": "F9 - 沃特森斯湾轮渡",
+            "zh-Hant": "F9 - 沃特森斯灣輪渡"
+        }
+    },
+    {
+        "id": "brkl",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Brooklyn Ferry",
+            "zh-Hans": "布鲁克林轮渡",
+            "zh-Hant": "布魯克林輪渡"
+        }
+    },
+    {
+        "id": "bunc",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Cronulla Bundeena Ferry",
+            "zh-Hans": "克洛努拉本迪娜轮渡",
+            "zh-Hant": "克洛努拉本迪娜輪渡"
+        }
+    },
+    {
+        "id": "cclc",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Lane Cove Ferry",
+            "zh-Hans": "拉恩科夫轮渡",
+            "zh-Hant": "拉恩科夫輪渡"
+        }
+    },
+    {
+        "id": "ccsh",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "City to Shark Island Ferry",
+            "zh-Hans": "市区至鲨岛轮渡",
+            "zh-Hant": "市區至鯊島輪渡"
+        }
+    },
+    {
+        "id": "cctz",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "City to Taronga Zoo Ferry",
+            "zh-Hans": "市区至塔隆加动物园快速轮渡",
+            "zh-Hant": "市區至塔隆加動物園快速輪渡"
+        }
+    },
+    {
+        "id": "ccwb",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "City to Watsons Bay Ferry",
+            "zh-Hans": "市区至沃特森斯湾快速轮渡",
+            "zh-Hant": "市區至沃特森斯灣快速輪渡"
+        }
+    },
+    {
+        "id": "ccwm",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "City to Manly via Watsons Bay Ferry",
+            "zh-Hans": "市区至曼利途径沃特森斯湾快速轮渡",
+            "zh-Hant": "市區至曼利途徑沃特森斯灣快速輪渡"
+        }
+    },
+    {
+        "id": "chcp",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Church Point Ferry",
+            "zh-Hans": "教堂点轮渡",
+            "zh-Hant": "教堂點輪渡"
+        }
+    },
+    {
+        "id": "crf",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Yamba to Iluka Ferry",
+            "zh-Hans": "雅姆巴至伊鲁卡轮渡",
+            "zh-Hant": "雅姆巴至伊魯卡輪渡"
+        }
+    },
+    {
+        "id": "empb",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Woy Woy Empire Bay Ferry",
+            "zh-Hans": "沃伊沃伊帝国湾轮渡",
+            "zh-Hant": "沃伊沃伊帝國灣輪渡"
+        }
+    },
+    {
+        "id": "mff",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Manly Fast Ferry",
+            "zh-Hans": "曼利快速轮渡",
+            "zh-Hant": "曼利快速輪渡"
+        }
+    },
+    {
+        "id": "plmb",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Palm Beach to Coasters Retreat Ferry",
+            "zh-Hans": "帕姆海滩至考斯特度假村轮渡",
+            "zh-Hant": "帕姆海灘至考斯特度假村輪渡"
+        }
+    },
+    {
+        "id": "wage",
+        "colour": "#5ab031",
+        "fg": "#fff",
+        "name": {
+            "en": "Palm Beach, Wagstaffe, Ettalong Ferry",
+            "zh-Hans": "帕姆海滩，瓦格斯塔夫，伊塔隆轮渡",
+            "zh-Hant": "帕姆海灘，瓦格斯塔夫，伊塔隆輪渡"
+        }
+    },
+    {
+        "id": "syl1",
+        "colour": "#be1622",
+        "fg": "#fff",
+        "name": {
+            "en": "L1 - Dulwich Hill Line",
+            "zh-Hans": "L1 - 道尔维奇山轻轨",
+            "zh-Hant": "L1 - 道爾維奇山輕軌"
+        }
+    },
+    {
+        "id": "syl2",
+        "colour": "#dd1e25",
+        "fg": "#fff",
+        "name": {
+            "en": "L2 - Randwick Line",
+            "zh-Hans": "L2 - 兰德维克轻轨",
+            "zh-Hant": "L2 - 蘭德維克輕軌"
+        }
+    },
+    {
+        "id": "syl3",
+        "colour": "#781140",
+        "fg": "#fff",
+        "name": {
+            "en": "L3 - Kingsford Line",
+            "zh-Hans": "L3 - 金斯福德轻轨",
+            "zh-Hant": "L3 - 金斯福德輕軌"
+        }
+    },
+    {
+        "id": "sylx",
+        "colour": "#ee343f",
+        "fg": "#fff",
+        "name": {
+            "en": "LX - Special Event Service",
+            "zh-Hans": "LX - 特殊活动期间轻轨服务",
+            "zh-Hant": "LX - 特殊活動期間輕軌服務"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Sydney on behalf of Jimmilily.
This should fix #560

> @railmapgen/rmg-palette-resources@0.8.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

T1 - North Shore & Western Line: bg=`#f99d1c`, fg=`#fff`
T2 - Inner West & Leppington Line: bg=`#0098cd`, fg=`#fff`
T3 - Bankstown Line: bg=`#f37021`, fg=`#fff`
T4 - Eastern Suburbs & Illawarra Line: bg=`#005aa3`, fg=`#fff`
T5 - Cumberland Line: bg=`#c4258f`, fg=`#fff`
T7 - Olympic Park Line: bg=`#6f818e`, fg=`#fff`
T8 - Airport & South Line: bg=`#00954c`, fg=`#fff`
T9 - Northern Line test: bg=`#d11f2f`, fg=`#fff`
Metro North West Line: bg=`#168388`, fg=`#fff`
Blue Mountains Line: bg=`#f99d1c`, fg=`#fff`
Central Cost & Newcastle Line: bg=`#d11f2f`, fg=`#fff`
Hunter Line: bg=`#833134`, fg=`#fff`
South Coast Line: bg=`#005aa3`, fg=`#fff`
Southern Highlands Line: bg=`#00954c`, fg=`#fff`
F1 - Manly: bg=`#00774b`, fg=`#fff`
F2 - Taronga Zoo: bg=`#144734`, fg=`#fff`
F3 - Parramatta River: bg=`#648c3c`, fg=`#fff`
F4 - Pyrmont Bay: bg=`#bfd730`, fg=`#fff`
F5 - Neutral Bay: bg=`#286142`, fg=`#fff`
F6 - Mosman Bay: bg=`#00ab51`, fg=`#fff`
F7 - Double Bay: bg=`#00b189`, fg=`#fff`
F8 - Cockatoo Island: bg=`#55622b`, fg=`#fff`
F9 - Watsons Bay: bg=`#65b32e`, fg=`#fff`
Brooklyn Ferry: bg=`#5ab031`, fg=`#fff`
Cronulla Bundeena Ferry: bg=`#5ab031`, fg=`#fff`
Lane Cove Ferry: bg=`#5ab031`, fg=`#fff`
City to Shark Island Ferry: bg=`#5ab031`, fg=`#fff`
City to Taronga Zoo Ferry: bg=`#5ab031`, fg=`#fff`
City to Watsons Bay Ferry: bg=`#5ab031`, fg=`#fff`
City to Manly via Watsons Bay Ferry: bg=`#5ab031`, fg=`#fff`
Church Point Ferry: bg=`#5ab031`, fg=`#fff`
Yamba to Iluka Ferry: bg=`#5ab031`, fg=`#fff`
Woy Woy Empire Bay Ferry: bg=`#5ab031`, fg=`#fff`
Manly Fast Ferry: bg=`#5ab031`, fg=`#fff`
Palm Beach to Coasters Retreat Ferry: bg=`#5ab031`, fg=`#fff`
Palm Beach, Wagstaffe, Ettalong Ferry: bg=`#5ab031`, fg=`#fff`
L1 - Dulwich Hill Line: bg=`#be1622`, fg=`#fff`
L2 - Randwick Line: bg=`#dd1e25`, fg=`#fff`
L3 - Kingsford Line: bg=`#781140`, fg=`#fff`
LX - Special Event Service: bg=`#ee343f`, fg=`#fff`