### PR TITLE
Resources: New palettes of Lanzhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -590,6 +590,16 @@
         }
     },
     {
+        "id": "lanzhou",
+        "country": "CN",
+        "name": {
+            "en": "Lanzhou",
+            "ko": "란저우",
+            "zh-Hans": "兰州",
+            "zh-Hant": "蘭州"
+        }
+    },
+    {
         "id": "lima",
         "country": "PE",
         "name": {

--- a/public/resources/palettes/lanzhou.json
+++ b/public/resources/palettes/lanzhou.json
@@ -1,0 +1,57 @@
+[
+    {
+        "id": "lz1",
+        "colour": "#0080bc",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "ko": "1호선",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線"
+        }
+    },
+    {
+        "id": "lz2",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "ko": "2호선",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線"
+        }
+    },
+    {
+        "id": "lz3",
+        "colour": "#8b4513",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "ko": "3호선",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線"
+        }
+    },
+    {
+        "id": "lz4",
+        "colour": "#008000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "ko": "4호선",
+            "zh-Hans": "4号线",
+            "zh-Hant": "4號線"
+        }
+    },
+    {
+        "id": "lz5",
+        "colour": "#c71585",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "ko": "5호선",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Lanzhou on behalf of 28yfang.
This should fix #548

> @railmapgen/rmg-palette-resources@0.8.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#0080bc`, fg=`#fff`
Line 2: bg=`#ff0000`, fg=`#fff`
Line 3: bg=`#8b4513`, fg=`#fff`
Line 4: bg=`#008000`, fg=`#fff`
Line 5: bg=`#c71585`, fg=`#fff`