### PR TITLE
Resources: New palettes of Los Angeles

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -629,6 +629,16 @@
         }
     },
     {
+        "id": "losangeles",
+        "country": "US",
+        "name": {
+            "en": "Los Angeles",
+            "zh-Hans": "洛杉矶",
+            "zh-Hant": "洛杉磯",
+            "ko": "로스 앤젤레스"
+        }
+    },
+    {
         "id": "luoyang",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/losangeles.json
+++ b/public/resources/palettes/losangeles.json
@@ -1,0 +1,101 @@
+[
+    {
+        "id": "laa",
+        "colour": "#0072bc",
+        "fg": "#fff",
+        "name": {
+            "en": "A Line",
+            "zh-Hans": "A线",
+            "zh-Hant": "A線",
+            "ko": "A선"
+        }
+    },
+    {
+        "id": "lab",
+        "colour": "#e3131b",
+        "fg": "#fff",
+        "name": {
+            "en": "B Line",
+            "zh-Hans": "B线",
+            "zh-Hant": "B線",
+            "ko": "B선"
+        }
+    },
+    {
+        "id": "lac",
+        "colour": "#58a738",
+        "fg": "#fff",
+        "name": {
+            "en": "C Line",
+            "zh-Hans": "C线",
+            "zh-Hant": "C線",
+            "ko": "C선"
+        }
+    },
+    {
+        "id": "lad",
+        "colour": "#a05da5",
+        "fg": "#fff",
+        "name": {
+            "en": "D Line",
+            "zh-Hans": "D线",
+            "zh-Hant": "D線",
+            "ko": "D선"
+        }
+    },
+    {
+        "id": "lae",
+        "colour": "#5bc2e7",
+        "fg": "#000",
+        "name": {
+            "en": "E Line",
+            "zh-Hans": "E线",
+            "zh-Hant": "E線",
+            "ko": "E선"
+        }
+    },
+    {
+        "id": "lak",
+        "colour": "#e96bb0",
+        "fg": "#000",
+        "name": {
+            "en": "K Line",
+            "zh-Hans": "K线",
+            "zh-Hant": "K線",
+            "ko": "K선"
+        }
+    },
+    {
+        "id": "lal",
+        "colour": "#fdb913",
+        "fg": "#000",
+        "name": {
+            "en": "L Line",
+            "zh-Hans": "L线",
+            "zh-Hant": "L線",
+            "ko": "L선"
+        }
+    },
+    {
+        "id": "lag",
+        "colour": "#fc4c02",
+        "fg": "#fff",
+        "name": {
+            "en": "G Line",
+            "zh-Hans": "快速公交G线",
+            "zh-Hant": "快速公交G線",
+            "ko": "G선"
+        }
+    },
+    {
+        "id": "laj",
+        "colour": "#adb8bf",
+        "fg": "#000",
+        "name": {
+            "en": "J Line",
+            "zh-Hans": "快速公交J线",
+            "zh-Hant": "快速公交J線",
+            "ko": "J선"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Los Angeles on behalf of aaronyz2007.
This should fix #567

> @railmapgen/rmg-palette-resources@0.8.3 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

A Line: bg=`#0072bc`, fg=`#fff`
B Line: bg=`#e3131b`, fg=`#fff`
C Line: bg=`#58a738`, fg=`#fff`
D Line: bg=`#a05da5`, fg=`#fff`
E Line: bg=`#5bc2e7`, fg=`#000`
K Line: bg=`#e96bb0`, fg=`#000`
L Line: bg=`#fdb913`, fg=`#000`
G Line: bg=`#fc4c02`, fg=`#fff`
J Line: bg=`#adb8bf`, fg=`#000`