### PR TITLE
Resources: New palettes of Melbourne

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -685,6 +685,15 @@
         }
     },
     {
+        "id": "melbourne",
+        "country": "AU",
+        "name": {
+            "en": "Melbourne",
+            "zh-Hans": "墨尔本",
+            "zh-Hant": "墨爾本"
+        }
+    },
+    {
         "id": "milan",
         "country": "IT",
         "name": {

--- a/public/resources/palettes/melbourne.json
+++ b/public/resources/palettes/melbourne.json
@@ -1,0 +1,362 @@
+[
+    {
+        "id": "abgl",
+        "colour": "#152c6b",
+        "fg": "#fff",
+        "name": {
+            "en": "Alamein, Belgrave, Glen Waverley and Lilydale Line",
+            "zh-Hans": "阿拉曼,贝尔格雷弗,格伦威弗利和利里黛尔线",
+            "zh-Hant": "阿拉曼,貝爾格雷弗,格倫威弗利和利裡黛爾線"
+        }
+    },
+    {
+        "id": "crpa",
+        "colour": "#279fd5",
+        "fg": "#fff",
+        "name": {
+            "en": "Cranbourne and Pakenham Line",
+            "zh-Hans": "克兰伯恩和帕肯海姆线",
+            "zh-Hant": "克蘭伯恩和帕肯海姆線"
+        }
+    },
+    {
+        "id": "hume",
+        "colour": "#be1014",
+        "fg": "#fff",
+        "name": {
+            "en": "Hurstbridge and Mernda Line",
+            "zh-Hans": "赫斯特桥和莫恩达线",
+            "zh-Hant": "赫斯特橋和莫恩達線"
+        }
+    },
+    {
+        "id": "csul",
+        "colour": "#ffbe00",
+        "fg": "#fff",
+        "name": {
+            "en": "Craigieburn, Sunbury and Upfield Line",
+            "zh-Hans": "克雷吉伯恩,桑伯里和上田线",
+            "zh-Hant": "克雷吉伯恩,桑伯里和上田線"
+        }
+    },
+    {
+        "id": "flrc",
+        "colour": "#95979a",
+        "fg": "#fff",
+        "name": {
+            "en": "Flemington Racecourse Line",
+            "zh-Hans": "弗雷明顿赛马场线",
+            "zh-Hant": "弗雷明頓賽馬場線"
+        }
+    },
+    {
+        "id": "fwwl",
+        "colour": "#028430",
+        "fg": "#fff",
+        "name": {
+            "en": "Frankston, Werribee and Williamstown Line",
+            "zh-Hans": "弗兰克斯顿,维利比和威廉斯托恩线",
+            "zh-Hant": "弗蘭克斯頓,維利比和威廉斯托恩線"
+        }
+    },
+    {
+        "id": "mlsd",
+        "colour": "#f178af",
+        "fg": "#fff",
+        "name": {
+            "en": "Sandringham Line",
+            "zh-Hans": "桑德岭海姆线",
+            "zh-Hant": "桑德嶺海姆線"
+        }
+    },
+    {
+        "id": "stpt",
+        "colour": "#028430",
+        "fg": "#fff",
+        "name": {
+            "en": "Stony Point Line",
+            "zh-Hans": "斯通尼点线",
+            "zh-Hant": "斯通尼點線"
+        }
+    },
+    {
+        "id": "mlvl",
+        "colour": "#7f0d82",
+        "fg": "#fff",
+        "name": {
+            "en": "V/Line",
+            "zh-Hans": "V/城际铁路",
+            "zh-Hant": "V/城際鐵路"
+        }
+    },
+    {
+        "id": "mt1",
+        "colour": "#b5c426",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 1",
+            "zh-Hans": "电车1路",
+            "zh-Hant": "電車1路"
+        }
+    },
+    {
+        "id": "mt3",
+        "colour": "#88d1f0",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 3",
+            "zh-Hans": "电车3路",
+            "zh-Hant": "電車3路"
+        }
+    },
+    {
+        "id": "mt3a",
+        "colour": "#88d1f0",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 3a",
+            "zh-Hans": "电车3a路",
+            "zh-Hant": "電車3a路"
+        }
+    },
+    {
+        "id": "mt5",
+        "colour": "#e04038",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 5",
+            "zh-Hans": "电车5路",
+            "zh-Hant": "電車5路"
+        }
+    },
+    {
+        "id": "mt5a",
+        "colour": "#e04038",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 5a",
+            "zh-Hans": "电车5a路",
+            "zh-Hant": "電車5a路"
+        }
+    },
+    {
+        "id": "mt6",
+        "colour": "#004c6c",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 6",
+            "zh-Hans": "电车6路",
+            "zh-Hant": "電車6路"
+        }
+    },
+    {
+        "id": "mt11",
+        "colour": "#86c5a2",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 11",
+            "zh-Hans": "电车11路",
+            "zh-Hant": "電車11路"
+        }
+    },
+    {
+        "id": "mt12",
+        "colour": "#008995",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 12",
+            "zh-Hans": "电车12路",
+            "zh-Hant": "電車12路"
+        }
+    },
+    {
+        "id": "mt16",
+        "colour": "#ffda66",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 16",
+            "zh-Hans": "电车16路",
+            "zh-Hant": "電車16路"
+        }
+    },
+    {
+        "id": "mt19",
+        "colour": "#8f4a78",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 19",
+            "zh-Hans": "电车19路",
+            "zh-Hant": "電車19路"
+        }
+    },
+    {
+        "id": "mt30",
+        "colour": "#4f4a9f",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 30",
+            "zh-Hans": "电车30路",
+            "zh-Hant": "電車30路"
+        }
+    },
+    {
+        "id": "mt35",
+        "colour": "#723b1f",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 35",
+            "zh-Hans": "电车35路",
+            "zh-Hant": "電車35路"
+        }
+    },
+    {
+        "id": "mt48",
+        "colour": "#434244",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 48",
+            "zh-Hans": "电车48路",
+            "zh-Hant": "電車48路"
+        }
+    },
+    {
+        "id": "mt57",
+        "colour": "#33bdca",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 57",
+            "zh-Hans": "电车57路",
+            "zh-Hant": "電車57路"
+        }
+    },
+    {
+        "id": "mt58",
+        "colour": "#83898f",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 58",
+            "zh-Hans": "电车58路",
+            "zh-Hant": "電車58路"
+        }
+    },
+    {
+        "id": "mt59",
+        "colour": "#49805b",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 59",
+            "zh-Hans": "电车59路",
+            "zh-Hant": "電車59路"
+        }
+    },
+    {
+        "id": "mt64",
+        "colour": "#1aaa6f",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 64",
+            "zh-Hans": "电车64路",
+            "zh-Hant": "電車64路"
+        }
+    },
+    {
+        "id": "mt67",
+        "colour": "#ac7963",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 67",
+            "zh-Hans": "电车67路",
+            "zh-Hant": "電車67路"
+        }
+    },
+    {
+        "id": "mt70",
+        "colour": "#f38bb9",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 70",
+            "zh-Hans": "电车70路",
+            "zh-Hant": "電車70路"
+        }
+    },
+    {
+        "id": "mt72",
+        "colour": "#9eb4a5",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 72",
+            "zh-Hans": "电车72路",
+            "zh-Hant": "電車72路"
+        }
+    },
+    {
+        "id": "mt75",
+        "colour": "#009fda",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 75",
+            "zh-Hans": "电车75路",
+            "zh-Hant": "電車75路"
+        }
+    },
+    {
+        "id": "mt78",
+        "colour": "#897cd9",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 78",
+            "zh-Hans": "电车78路",
+            "zh-Hant": "電車78路"
+        }
+    },
+    {
+        "id": "mt82",
+        "colour": "#bed639",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 82",
+            "zh-Hans": "电车82路",
+            "zh-Hant": "電車82路"
+        }
+    },
+    {
+        "id": "mt86",
+        "colour": "#feba10",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 86",
+            "zh-Hans": "电车86路",
+            "zh-Hant": "電車86路"
+        }
+    },
+    {
+        "id": "mt96",
+        "colour": "#e33385",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 96",
+            "zh-Hans": "电车96路",
+            "zh-Hant": "電車96路"
+        }
+    },
+    {
+        "id": "mt109",
+        "colour": "#f58122",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram 109",
+            "zh-Hans": "电车109路",
+            "zh-Hant": "電車109路"
+        }
+    },
+    {
+        "id": "mlaf",
+        "colour": "#f95602",
+        "fg": "#fff",
+        "name": {
+            "en": "Melbourne Airport Line",
+            "zh-Hans": "墨尔本机场线",
+            "zh-Hant": "墨爾本機場線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Melbourne on behalf of Jimmilily.
This should fix #580

> @railmapgen/rmg-palette-resources@0.8.5 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Alamein, Belgrave, Glen Waverley and Lilydale Line: bg=`#152c6b`, fg=`#fff`
Cranbourne and Pakenham Line: bg=`#279fd5`, fg=`#fff`
Hurstbridge and Mernda Line: bg=`#be1014`, fg=`#fff`
Craigieburn, Sunbury and Upfield Line: bg=`#ffbe00`, fg=`#fff`
Flemington Racecourse Line: bg=`#95979a`, fg=`#fff`
Frankston, Werribee and Williamstown Line: bg=`#028430`, fg=`#fff`
Sandringham Line: bg=`#f178af`, fg=`#fff`
Stony Point Line: bg=`#028430`, fg=`#fff`
V/Line: bg=`#7f0d82`, fg=`#fff`
Tram 1: bg=`#b5c426`, fg=`#fff`
Tram 3: bg=`#88d1f0`, fg=`#fff`
Tram 3a: bg=`#88d1f0`, fg=`#fff`
Tram 5: bg=`#e04038`, fg=`#fff`
Tram 5a: bg=`#e04038`, fg=`#fff`
Tram 6: bg=`#004c6c`, fg=`#fff`
Tram 11: bg=`#86c5a2`, fg=`#fff`
Tram 12: bg=`#008995`, fg=`#fff`
Tram 16: bg=`#ffda66`, fg=`#fff`
Tram 19: bg=`#8f4a78`, fg=`#fff`
Tram 30: bg=`#4f4a9f`, fg=`#fff`
Tram 35: bg=`#723b1f`, fg=`#fff`
Tram 48: bg=`#434244`, fg=`#fff`
Tram 57: bg=`#33bdca`, fg=`#fff`
Tram 58: bg=`#83898f`, fg=`#fff`
Tram 59: bg=`#49805b`, fg=`#fff`
Tram 64: bg=`#1aaa6f`, fg=`#fff`
Tram 67: bg=`#ac7963`, fg=`#fff`
Tram 70: bg=`#f38bb9`, fg=`#fff`
Tram 72: bg=`#9eb4a5`, fg=`#fff`
Tram 75: bg=`#009fda`, fg=`#fff`
Tram 78: bg=`#897cd9`, fg=`#fff`
Tram 82: bg=`#bed639`, fg=`#fff`
Tram 86: bg=`#feba10`, fg=`#fff`
Tram 96: bg=`#e33385`, fg=`#fff`
Tram 109: bg=`#f58122`, fg=`#fff`
Melbourne Airport Line: bg=`#f95602`, fg=`#fff`