### PR TITLE
Resources: New palettes of Perth

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -866,6 +866,15 @@
         }
     },
     {
+        "id": "perth",
+        "country": "AU",
+        "name": {
+            "en": "Perth",
+            "zh-Hans": "珀斯",
+            "zh-Hant": "珀斯"
+        }
+    },
+    {
         "id": "qingdao",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/perth.json
+++ b/public/resources/palettes/perth.json
@@ -1,0 +1,72 @@
+[
+    {
+        "id": "arth",
+        "colour": "#f6a800",
+        "fg": "#fff",
+        "name": {
+            "en": "Armadale/Thornlie Line",
+            "zh-Hans": "阿玛黛尔/颂恩莱线",
+            "zh-Hant": "阿瑪黛爾/頌恩萊線"
+        }
+    },
+    {
+        "id": "phfr",
+        "colour": "#003a79",
+        "fg": "#fff",
+        "name": {
+            "en": "Fremantle Line",
+            "zh-Hans": "弗里曼特尔线",
+            "zh-Hant": "弗里曼特爾線"
+        }
+    },
+    {
+        "id": "phjo",
+        "colour": "#959300",
+        "fg": "#fff",
+        "name": {
+            "en": "Joondalup Line",
+            "zh-Hans": "俊达拉普线",
+            "zh-Hant": "俊達拉普線"
+        }
+    },
+    {
+        "id": "phma",
+        "colour": "#d25f15",
+        "fg": "#fff",
+        "name": {
+            "en": "Mandurah Line",
+            "zh-Hans": "曼杜拉尔线",
+            "zh-Hant": "曼杜拉爾線"
+        }
+    },
+    {
+        "id": "phmi",
+        "colour": "#960048",
+        "fg": "#fff",
+        "name": {
+            "en": "Midland Line",
+            "zh-Hans": "米德兰德线",
+            "zh-Hant": "米德蘭德線"
+        }
+    },
+    {
+        "id": "phaf",
+        "colour": "#44c2b2",
+        "fg": "#fff",
+        "name": {
+            "en": "Airport Line",
+            "zh-Hans": "机场线",
+            "zh-Hant": "機場線"
+        }
+    },
+    {
+        "id": "phel",
+        "colour": "#d2222c",
+        "fg": "#fff",
+        "name": {
+            "en": "Ellenbrook Line",
+            "zh-Hans": "艾伦布鲁克线",
+            "zh-Hant": "艾倫布魯克線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Perth on behalf of Jimmilily.
This should fix #582

> @railmapgen/rmg-palette-resources@0.8.5 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Armadale/Thornlie Line: bg=`#f6a800`, fg=`#fff`
Fremantle Line: bg=`#003a79`, fg=`#fff`
Joondalup Line: bg=`#959300`, fg=`#fff`
Mandurah Line: bg=`#d25f15`, fg=`#fff`
Midland Line: bg=`#960048`, fg=`#fff`
Airport Line: bg=`#44c2b2`, fg=`#fff`
Ellenbrook Line: bg=`#d2222c`, fg=`#fff`