### PR TITLE
Resources: New palettes of Adelaide

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1,5 +1,14 @@
 [
     {
+        "id": "adelaide",
+        "country": "AU",
+        "name": {
+            "en": "Adelaide",
+            "zh-Hans": "阿德莱德",
+            "zh-Hant": "阿德萊德"
+        }
+    },
+    {
         "id": "amsterdam",
         "country": "NL",
         "name": {

--- a/public/resources/palettes/adelaide.json
+++ b/public/resources/palettes/adelaide.json
@@ -1,0 +1,92 @@
+[
+    {
+        "id": "bel",
+        "colour": "#009900",
+        "fg": "#fff",
+        "name": {
+            "en": "Belair Line",
+            "zh-Hans": "贝埃尔线",
+            "zh-Hant": "貝埃爾線"
+        }
+    },
+    {
+        "id": "gawc",
+        "colour": "#9c2727",
+        "fg": "#fff",
+        "name": {
+            "en": "Gawler Line",
+            "zh-Hans": "高乐尔线",
+            "zh-Hant": "高樂爾線"
+        }
+    },
+    {
+        "id": "grot",
+        "colour": "#0072c6",
+        "fg": "#fff",
+        "name": {
+            "en": "Outer Harbor and Grange Line",
+            "zh-Hans": "外港和格兰吉线",
+            "zh-Hant": "外港和格蘭吉線"
+        }
+    },
+    {
+        "id": "sefl",
+        "colour": "#ff7f00",
+        "fg": "#fff",
+        "name": {
+            "en": "Seaford and Flinders Line",
+            "zh-Hans": "斯弗德和弗林德斯线",
+            "zh-Hant": "斯弗德和弗林德斯線"
+        }
+    },
+    {
+        "id": "showg",
+        "colour": "#808080",
+        "fg": "#fff",
+        "name": {
+            "en": "Showground Line",
+            "zh-Hans": "阿德莱德展览场线",
+            "zh-Hant": "阿德萊德展覽場線"
+        }
+    },
+    {
+        "id": "glnelg",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Glenelg to Royal Adelaide Hospital Line",
+            "zh-Hans": "格雷内尔格至阿德莱德皇家医院电车",
+            "zh-Hant": "格雷內爾格至阿德萊德皇家醫院電車"
+        }
+    },
+    {
+        "id": "btanic",
+        "colour": "#ffd700",
+        "fg": "#fff",
+        "name": {
+            "en": "Botanic Gardens to Entertainment Centre Line",
+            "zh-Hans": "植物园至文娱中心电车",
+            "zh-Hant": "植物園至文娛中心電車"
+        }
+    },
+    {
+        "id": "festvl",
+        "colour": "#0072c6",
+        "fg": "#fff",
+        "name": {
+            "en": "Glenelg to Festival Plaza Line",
+            "zh-Hans": "格雷内尔格至节日广场电车",
+            "zh-Hant": "格雷內爾格至節日廣場電車"
+        }
+    },
+    {
+        "id": "adloop",
+        "colour": "#800080",
+        "fg": "#fff",
+        "name": {
+            "en": "Adelaide City Loop",
+            "zh-Hans": "阿德莱德市区循环电车",
+            "zh-Hant": "阿德萊德市區循環電車"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Adelaide on behalf of Jimmilily.
This should fix #584

> @railmapgen/rmg-palette-resources@0.8.5 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Belair Line: bg=`#009900`, fg=`#fff`
Gawler Line: bg=`#9c2727`, fg=`#fff`
Outer Harbor and Grange Line: bg=`#0072c6`, fg=`#fff`
Seaford and Flinders Line: bg=`#ff7f00`, fg=`#fff`
Showground Line: bg=`#808080`, fg=`#fff`
Glenelg to Royal Adelaide Hospital Line: bg=`#ff0000`, fg=`#fff`
Botanic Gardens to Entertainment Centre Line: bg=`#ffd700`, fg=`#fff`
Glenelg to Festival Plaza Line: bg=`#0072c6`, fg=`#fff`
Adelaide City Loop: bg=`#800080`, fg=`#fff`