### PR TITLE
资源：西安的新调色板

### DIFF
--- a/public/resources/palettes/xian.json
+++ b/public/resources/palettes/xian.json
@@ -1,92 +1,102 @@
 [
     {
         "id": "xa1",
+        "colour": "#0077C8",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#0077C8"
+        }
     },
     {
         "id": "xa2",
+        "colour": "#EF3340",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#EF3340"
+        }
     },
     {
         "id": "xa3",
+        "colour": "#CE70CC",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#CE70CC"
+        }
     },
     {
         "id": "xa4",
+        "colour": "#2CCCD3",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#2CCCD3"
+        }
     },
     {
         "id": "xa5",
+        "colour": "#A6E35F",
+        "fg": "#fff",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
             "zh-Hant": "5號線"
-        },
-        "colour": "#A6E35F"
+        }
     },
     {
         "id": "xa6",
+        "colour": "#485CC7",
+        "fg": "#fff",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
             "zh-Hant": "6號線"
-        },
-        "colour": "#485CC7"
+        }
     },
     {
         "id": "xa8",
+        "colour": "#FFE400",
+        "fg": "#fff",
         "name": {
             "en": "Line 8",
             "zh-Hans": "8号线",
             "zh-Hant": "8號線"
-        },
-        "colour": "#FFE400"
+        }
     },
     {
         "id": "xa9",
+        "colour": "#FF9E1B",
+        "fg": "#fff",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
             "zh-Hant": "9號線"
-        },
-        "colour": "#FF9E1B"
+        }
     },
     {
-        "id": "xa11",
+        "id": "xa10",
+        "colour": "#009f4d",
+        "fg": "#fff",
         "name": {
-            "en": "Line 11",
-            "zh-Hans": "11号线",
-            "zh-Hant": "11號線"
-        },
-        "colour": "#006400"
+            "en": "Line 10",
+            "zh-Hans": "10号线",
+            "zh-Hant": "10號線"
+        }
     },
     {
         "id": "xa14",
+        "colour": "#00C1D4",
+        "fg": "#000",
         "name": {
             "en": "Airport Intercity Railway/Line 14",
             "zh-Hans": "机场城际/14号线",
             "zh-Hant": "機場城際/14號線"
-        },
-        "colour": "#00C1D4"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating 资源：西安的新调色板 on behalf of XianningluStation.
This should fix #588

> @railmapgen/rmg-palette-resources@0.8.6 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#0077C8`, fg=`#fff`
Line 2: bg=`#EF3340`, fg=`#fff`
Line 3: bg=`#CE70CC`, fg=`#fff`
Line 4: bg=`#2CCCD3`, fg=`#fff`
Line 5: bg=`#A6E35F`, fg=`#fff`
Line 6: bg=`#485CC7`, fg=`#fff`
Line 8: bg=`#FFE400`, fg=`#fff`
Line 9: bg=`#FF9E1B`, fg=`#fff`
Line 10: bg=`#009f4d`, fg=`#fff`
Airport Intercity Railway/Line 14: bg=`#00C1D4`, fg=`#000`