### PR TITLE
Resources: New palettes of Wuhan

### DIFF
--- a/public/resources/palettes/wuhan.json
+++ b/public/resources/palettes/wuhan.json
@@ -1,146 +1,162 @@
 [
     {
         "id": "wh1",
+        "colour": "#3D84C6",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#3D84C6"
+        }
     },
     {
         "id": "wh2",
+        "colour": "#EB7CAF",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#EB7CAF"
+        }
     },
     {
         "id": "wh3",
+        "colour": "#D9B966",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#D9B966"
+        }
     },
     {
         "id": "wh4",
+        "colour": "#8EC720",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#8EC720"
+        }
     },
     {
         "id": "wh5",
+        "colour": "#a62e37",
+        "fg": "#fff",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
             "zh-Hant": "5號線"
-        },
-        "colour": "#E63F00"
+        }
     },
     {
         "id": "wh6",
+        "colour": "#008536",
+        "fg": "#fff",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
             "zh-Hant": "6號線"
-        },
-        "colour": "#008536"
+        }
     },
     {
         "id": "wh7",
+        "colour": "#EB7900",
+        "fg": "#fff",
         "name": {
             "en": "Line 7",
             "zh-Hans": "7号线",
             "zh-Hant": "7號線"
-        },
-        "colour": "#EB7900"
+        }
     },
     {
         "id": "wh8",
+        "colour": "#98ACAB",
+        "fg": "#fff",
         "name": {
             "en": "Line 8",
             "zh-Hans": "8号线",
             "zh-Hant": "8號線"
-        },
-        "colour": "#98ACAB"
+        }
     },
     {
         "id": "wh9",
+        "colour": "#A5D4AD",
+        "fg": "#fff",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
             "zh-Hant": "9號線"
-        },
-        "colour": "#A5D4AD"
+        }
     },
     {
         "id": "wh10",
+        "colour": "#8C3626",
+        "fg": "#fff",
         "name": {
             "en": "Line 10",
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
-        },
-        "colour": "#8C3626"
+        }
     },
     {
         "id": "wh11",
+        "colour": "#F2CF01",
+        "fg": "#fff",
         "name": {
             "en": "Line 11",
             "zh-Hans": "11号线",
             "zh-Hant": "11號線"
-        },
-        "colour": "#F2CF01"
+        }
     },
     {
         "id": "wh12",
+        "colour": "#00A3E9",
+        "fg": "#fff",
         "name": {
             "en": "Line 12",
             "zh-Hans": "12号线",
             "zh-Hant": "12號線"
-        },
-        "colour": "#00A3E9"
+        }
     },
     {
         "id": "wh13",
+        "colour": "#25CAD0",
+        "fg": "#fff",
         "name": {
             "en": "Line 13",
             "zh-Hans": "13号线",
             "zh-Hant": "13號線"
-        },
-        "colour": "#25CAD0"
+        }
     },
     {
         "id": "wh14",
+        "colour": "#7D55A3",
+        "fg": "#fff",
         "name": {
             "en": "Line 14",
             "zh-Hans": "14号线",
             "zh-Hant": "14號線"
-        },
-        "colour": "#7D55A3"
+        }
     },
     {
         "id": "wh16",
+        "colour": "#CC0256",
+        "fg": "#fff",
         "name": {
             "en": "Line 16",
             "zh-Hans": "16号线",
             "zh-Hant": "16號線"
-        },
-        "colour": "#CC0256"
+        }
     },
     {
         "id": "wh21",
+        "colour": "#CF0192",
+        "fg": "#fff",
         "name": {
             "en": "Line 21",
             "zh-Hans": "21号线",
             "zh-Hant": "21號線"
-        },
-        "colour": "#CF0192"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wuhan on behalf of LittleLing03.
This should fix #590

> @railmapgen/rmg-palette-resources@0.8.6 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#3D84C6`, fg=`#fff`
Line 2: bg=`#EB7CAF`, fg=`#fff`
Line 3: bg=`#D9B966`, fg=`#fff`
Line 4: bg=`#8EC720`, fg=`#fff`
Line 5: bg=`#a62e37`, fg=`#fff`
Line 6: bg=`#008536`, fg=`#fff`
Line 7: bg=`#EB7900`, fg=`#fff`
Line 8: bg=`#98ACAB`, fg=`#fff`
Line 9: bg=`#A5D4AD`, fg=`#fff`
Line 10: bg=`#8C3626`, fg=`#fff`
Line 11: bg=`#F2CF01`, fg=`#fff`
Line 12: bg=`#00A3E9`, fg=`#fff`
Line 13: bg=`#25CAD0`, fg=`#fff`
Line 14: bg=`#7D55A3`, fg=`#fff`
Line 16: bg=`#CC0256`, fg=`#fff`
Line 21: bg=`#CF0192`, fg=`#fff`