### PR TITLE
Resources: New palettes of Canberra

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -186,6 +186,15 @@
         }
     },
     {
+        "id": "cbr",
+        "country": "AU",
+        "name": {
+            "en": "Canberra",
+            "zh-Hans": "堪培拉",
+            "zh-Hant": "堪培拉"
+        }
+    },
+    {
         "id": "changchun",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/cbr.json
+++ b/public/resources/palettes/cbr.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "R1",
+        "colour": "#e9322b",
+        "fg": "#fff",
+        "name": {
+            "en": "Light Rail Line 1",
+            "zh-Hans": "轻轨1号线",
+            "zh-Hant": "輕軌1號線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Canberra on behalf of DQB061204.
This should fix #592

> @railmapgen/rmg-palette-resources@0.8.6 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Light Rail Line 1: bg=`#e9322b`, fg=`#fff`