### PR TITLE
Resources: New palettes of Xi'an

### DIFF
--- a/public/resources/palettes/xian.json
+++ b/public/resources/palettes/xian.json
@@ -31,7 +31,7 @@
     },
     {
         "id": "xa4",
-        "colour": "#2CCCD3",
+        "colour": "#39b09e",
         "fg": "#fff",
         "name": {
             "en": "Line 4",
@@ -60,16 +60,6 @@
         }
     },
     {
-        "id": "xa8",
-        "colour": "#FFE400",
-        "fg": "#fff",
-        "name": {
-            "en": "Line 8",
-            "zh-Hans": "8号线",
-            "zh-Hant": "8號線"
-        }
-    },
-    {
         "id": "xa9",
         "colour": "#FF9E1B",
         "fg": "#fff",
@@ -80,8 +70,18 @@
         }
     },
     {
+        "id": "xa14",
+        "colour": "#00C1D4",
+        "fg": "#000",
+        "name": {
+            "en": "Airport Intercity Railway/Line 14",
+            "zh-Hans": "机场城际/14号线",
+            "zh-Hant": "機場城際/14號線"
+        }
+    },
+    {
         "id": "xa10",
-        "colour": "#009f4d",
+        "colour": "#00a353",
         "fg": "#fff",
         "name": {
             "en": "Line 10",
@@ -90,13 +90,33 @@
         }
     },
     {
-        "id": "xa14",
-        "colour": "#00C1D4",
-        "fg": "#000",
+        "id": "xa16",
+        "colour": "#ee805f",
+        "fg": "#fff",
         "name": {
-            "en": "Airport Intercity Railway/Line 14",
-            "zh-Hans": "机场城际/14号线",
-            "zh-Hant": "機場城際/14號線"
+            "en": "Line 16",
+            "zh-Hans": "16号线",
+            "zh-Hant": "16號線"
+        }
+    },
+    {
+        "id": "xaxh",
+        "colour": "#720160",
+        "fg": "#fff",
+        "name": {
+            "en": "Xihu Line",
+            "zh-Hans": "西户线",
+            "zh-Hant": "西戶線"
+        }
+    },
+    {
+        "id": "xxzg",
+        "colour": "#bb0601",
+        "fg": "#fff",
+        "name": {
+            "en": "Xixian ART Line 1",
+            "zh-Hans": "西咸智轨1号线",
+            "zh-Hant": "西咸智軌1號線"
         }
     }
 ]

--- a/public/resources/palettes/xian.json
+++ b/public/resources/palettes/xian.json
@@ -70,16 +70,6 @@
         }
     },
     {
-        "id": "xa14",
-        "colour": "#00C1D4",
-        "fg": "#000",
-        "name": {
-            "en": "Airport Intercity Railway/Line 14",
-            "zh-Hans": "机场城际/14号线",
-            "zh-Hant": "機場城際/14號線"
-        }
-    },
-    {
         "id": "xa10",
         "colour": "#00a353",
         "fg": "#fff",
@@ -87,6 +77,16 @@
             "en": "Line 10",
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
+        }
+    },
+    {
+        "id": "xa14",
+        "colour": "#00C1D4",
+        "fg": "#000",
+        "name": {
+            "en": "Airport Intercity Railway/Line 14",
+            "zh-Hans": "机场城际/14号线",
+            "zh-Hant": "機場城際/14號線"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Xi'an on behalf of XianningluStation.
This should fix #577

> @railmapgen/rmg-palette-resources@0.8.6 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#0077C8`, fg=`#fff`
Line 2: bg=`#EF3340`, fg=`#fff`
Line 3: bg=`#CE70CC`, fg=`#fff`
Line 4: bg=`#39b09e`, fg=`#fff`
Line 5: bg=`#A6E35F`, fg=`#fff`
Line 6: bg=`#485CC7`, fg=`#fff`
Line 9: bg=`#FF9E1B`, fg=`#fff`
Airport Intercity Railway/Line 14: bg=`#00C1D4`, fg=`#000`
Line 10: bg=`#00a353`, fg=`#fff`
Line 16: bg=`#ee805f`, fg=`#fff`
Xihu Line: bg=`#720160`, fg=`#fff`
Xixian ART Line 1: bg=`#bb0601`, fg=`#fff`