### PR TITLE
Resources: New palettes of Pyongyang

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -893,6 +893,16 @@
         }
     },
     {
+        "id": "pyongyang",
+        "country": "KP",
+        "name": {
+            "en": "Pyongyang",
+            "zh-Hans": "平壤",
+            "zh-Hant": "平壤",
+            "ko": "평양"
+        }
+    },
+    {
         "id": "qingdao",
         "country": "CN",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -257,6 +257,16 @@
         "language": "ja"
     },
     {
+        "id": "KP",
+        "name": {
+            "en": "North Korea",
+            "zh-Hans": "朝鲜民主主义人民共和国",
+            "zh-Hant": "朝鮮民主主義人民共和國",
+            "ko": "조선민주주의인민공화국"
+        },
+        "language": "ko"
+    },
+    {
         "id": "KR",
         "name": {
             "en": "South Korea",

--- a/public/resources/palettes/pyongyang.json
+++ b/public/resources/palettes/pyongyang.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "chollima",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Chollima Line",
+            "zh-Hans": "千里马线",
+            "ko": "천리마선",
+            "zh-Hant": "千里馬線"
+        }
+    },
+    {
+        "id": "hyeoksin",
+        "colour": "#00aa00",
+        "fg": "#fff",
+        "name": {
+            "en": "Hyŏksin Line",
+            "zh-Hans": "革新线",
+            "ko": "혁신선",
+            "zh-Hant": "革新線"
+        }
+    }
+]

--- a/public/resources/palettes/pyongyang.json
+++ b/public/resources/palettes/pyongyang.json
@@ -12,7 +12,7 @@
     },
     {
         "id": "hyeoksin",
-        "colour": "#00aa00",
+        "colour": "#00ff00",
         "fg": "#fff",
         "name": {
             "en": "Hyŏksin Line",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Pyongyang on behalf of coxine.
This should fix #595

> @railmapgen/rmg-palette-resources@0.8.7 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Chollima Line: bg=`#ff0000`, fg=`#fff`
Hyŏksin Line: bg=`#00aa00`, fg=`#fff`