### PR TITLE
Resources: New palettes of Nantes

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -771,6 +771,16 @@
         }
     },
     {
+        "id": "nantes",
+        "country": "FR",
+        "name": {
+            "en": "Nantes",
+            "fr": "Nantes",
+            "zh-Hans": "南特",
+            "zh-Hant": "南特"
+        }
+    },
+    {
         "id": "nantong",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/nantes.json
+++ b/public/resources/palettes/nantes.json
@@ -1,0 +1,57 @@
+[
+    {
+        "id": "n1",
+        "colour": "#007a45",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號缐",
+            "fr": "Ligne 1"
+        }
+    },
+    {
+        "id": "n2",
+        "colour": "#e53138",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號缐",
+            "fr": "Ligne 2"
+        }
+    },
+    {
+        "id": "n3",
+        "colour": "#0079bc",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號缐",
+            "fr": "Ligne 3"
+        }
+    },
+    {
+        "id": "n4",
+        "colour": "#fdc600",
+        "fg": "#000",
+        "name": {
+            "en": "Line 4",
+            "zh-Hans": "4号线",
+            "zh-Hant": "4號缐",
+            "fr": "Ligne 4"
+        }
+    },
+    {
+        "id": "n5",
+        "colour": "#34b4e4",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號缐",
+            "fr": "Ligne 5"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nantes on behalf of linchen1965.
This should fix #600

> @railmapgen/rmg-palette-resources@0.8.9 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#007a45`, fg=`#fff`
Line 2: bg=`#e53138`, fg=`#fff`
Line 3: bg=`#0079bc`, fg=`#fff`
Line 4: bg=`#fdc600`, fg=`#000`
Line 5: bg=`#34b4e4`, fg=`#fff`