### PR TITLE
Resources: New palettes of Nagpur

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -743,6 +743,16 @@
         }
     },
     {
+        "id": "nagpur",
+        "country": "IN",
+        "name": {
+            "en": "Nagpur",
+            "zh-Hans": "那格浦尔",
+            "zh-Hant": "那格浦爾",
+            "hi": "नागपुर"
+        }
+    },
+    {
         "id": "nanchang",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/nagpur.json
+++ b/public/resources/palettes/nagpur.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "aqua",
+        "colour": "#0288d1",
+        "fg": "#fff",
+        "name": {
+            "en": "Aqua Line",
+            "zh-Hans": "水线",
+            "zh-Hant": "水線",
+            "hi": "एक्वा लाइन"
+        }
+    },
+    {
+        "id": "orange",
+        "colour": "#f57c00",
+        "fg": "#fff",
+        "name": {
+            "en": "Orange Line",
+            "zh-Hans": "橙线",
+            "zh-Hant": "橙線",
+            "hi": "ऑरेंज लाइन"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nagpur on behalf of DQB061204.
This should fix #602

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Aqua Line: bg=`#0288d1`, fg=`#fff`
Orange Line: bg=`#f57c00`, fg=`#fff`