### PR TITLE
Resources: New palettes of Shiraz

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1074,6 +1074,16 @@
         }
     },
     {
+        "id": "shiraz",
+        "country": "IR",
+        "name": {
+            "en": "Shiraz",
+            "zh-Hans": "设拉子",
+            "zh-Hant": "設拉子",
+            "fa": "شیراز"
+        }
+    },
+    {
         "id": "singapore",
         "country": "SG",
         "name": {

--- a/public/resources/palettes/shiraz.json
+++ b/public/resources/palettes/shiraz.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "L1",
+        "colour": "#ea1d23",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "一号线",
+            "zh-Hant": "一號線",
+            "fa": "خط ۱"
+        }
+    }
+]

--- a/public/resources/palettes/shiraz.json
+++ b/public/resources/palettes/shiraz.json
@@ -1,12 +1,12 @@
 [
     {
-        "id": "L1",
+        "id": "shiraz1",
         "colour": "#ea1d23",
         "fg": "#fff",
         "name": {
             "en": "Line 1",
-            "zh-Hans": "一号线",
-            "zh-Hant": "一號線",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線",
             "fa": "خط ۱"
         }
     }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shiraz on behalf of DQB061204.
This should fix #604

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#ea1d23`, fg=`#fff`