### PR TITLE
Resources: New palettes of Turin

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1193,6 +1193,16 @@
         }
     },
     {
+        "id": "turin",
+        "country": "IT",
+        "name": {
+            "en": "Turin",
+            "zh-Hans": "都灵",
+            "zh-Hant": "都靈",
+            "it": "Torino"
+        }
+    },
+    {
         "id": "tyneandwear",
         "country": "GBENG",
         "name": {

--- a/public/resources/palettes/turin.json
+++ b/public/resources/palettes/turin.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "m1",
+        "colour": "#feed03",
+        "fg": "#000",
+        "name": {
+            "en": "Metro Line 1",
+            "zh-Hans": "地铁一号线",
+            "zh-Hant": "捷運一號線",
+            "it": "M1"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Turin on behalf of DQB061204.
This should fix #606

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Metro Line 1: bg=`#feed03`, fg=`#000`