### PR TITLE
Resources: New palettes of Almaty

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -9,6 +9,16 @@
         }
     },
     {
+        "id": "almaty",
+        "country": "KZ",
+        "name": {
+            "en": "Almaty",
+            "zh-Hans": "阿拉木图",
+            "zh-Hant": "阿拉木圖",
+            "uz": "Алматы"
+        }
+    },
+    {
         "id": "amsterdam",
         "country": "NL",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -277,6 +277,16 @@
         "language": "ko"
     },
     {
+        "id": "KZ",
+        "name": {
+            "en": "Kazakhstan",
+            "zh-Hans": "哈萨克斯坦",
+            "zh-Hant": "哈薩克",
+            "uz": "Қазақстан"
+        },
+        "language": "uz"
+    },
+    {
         "id": "MO",
         "name": {
             "en": "Macao",

--- a/public/resources/palettes/almaty.json
+++ b/public/resources/palettes/almaty.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "m",
+        "colour": "#fbab87",
+        "fg": "#fff",
+        "name": {
+            "en": "Metro",
+            "zh-Hans": "地铁",
+            "zh-Hant": "捷運",
+            "uz": "Метрополитен"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Almaty on behalf of DQB061204.
This should fix #608

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Metro: bg=`#fbab87`, fg=`#fff`