### PR TITLE
Resources: New palettes of Lahore

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -612,6 +612,7 @@
         "country": "PK",
         "name": {
             "en": "Lahore",
+            "ur": "لاہور‬‎‎",
             "zh-Hans": "拉合尔",
             "zh-Hant": "拉合爾"
         }

--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -622,7 +622,7 @@
         "country": "PK",
         "name": {
             "en": "Lahore",
-            "ur": "لاہور‬",
+            "ur": "لاہور‬‎‎",
             "zh-Hans": "拉合尔",
             "zh-Hant": "拉合爾"
         }

--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -608,6 +608,15 @@
         }
     },
     {
+        "id": "lahore",
+        "country": "PK",
+        "name": {
+            "en": "Lahore",
+            "zh-Hans": "拉合尔",
+            "zh-Hant": "拉合爾"
+        }
+    },
+    {
         "id": "lanzhou",
         "country": "CN",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -336,6 +336,15 @@
         "language": "es"
     },
     {
+        "id": "PK",
+        "name": {
+            "en": "Pakistan",
+            "zh-Hans": "巴基斯坦",
+            "zh-Hant": "巴基斯坦"
+        },
+        "language": "en"
+    },
+    {
         "id": "PL",
         "name": {
             "en": "Poland",

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -339,10 +339,11 @@
         "id": "PK",
         "name": {
             "en": "Pakistan",
+            "ur": "پاکستان",
             "zh-Hans": "巴基斯坦",
             "zh-Hant": "巴基斯坦"
         },
-        "language": "en"
+        "language": "ur"
     },
     {
         "id": "PL",

--- a/public/resources/palettes/lahore.json
+++ b/public/resources/palettes/lahore.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "orange",
+        "colour": "#f66725",
+        "fg": "#fff",
+        "name": {
+            "en": "Orange Line",
+            "zh-Hans": "橙线",
+            "zh-Hant": "橙線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Lahore on behalf of DQB061204.
This should fix #612

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Orange Line: bg=`#f66725`, fg=`#fff`