### PR TITLE
Resources: New palettes of Kyiv

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -608,6 +608,16 @@
         }
     },
     {
+        "id": "kyiv",
+        "country": "UA",
+        "name": {
+            "en": "Kyiv",
+            "zh-Hans": "基辅",
+            "zh-Hant": "基輔",
+            "ru": "Киев"
+        }
+    },
+    {
         "id": "lanzhou",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/kyiv.json
+++ b/public/resources/palettes/kyiv.json
@@ -1,0 +1,35 @@
+[
+    {
+        "id": "m1",
+        "colour": "#e53027",
+        "fg": "#fff",
+        "name": {
+            "en": "Metro Line 1",
+            "zh-Hans": "地铁一号线",
+            "zh-Hant": "捷運一號線",
+            "ru": "M1"
+        }
+    },
+    {
+        "id": "m2",
+        "colour": "#2385c6",
+        "fg": "#fff",
+        "name": {
+            "en": "Metro Line 2",
+            "zh-Hans": "地铁二号线",
+            "zh-Hant": "捷運二號線",
+            "ru": "M2"
+        }
+    },
+    {
+        "id": "m3",
+        "colour": "#34b660",
+        "fg": "#fff",
+        "name": {
+            "en": "Metro Line 3",
+            "zh-Hans": "地铁三号线",
+            "zh-Hant": "捷運三號線",
+            "ru": "M3"
+        }
+    }
+]

--- a/public/resources/palettes/kyiv.json
+++ b/public/resources/palettes/kyiv.json
@@ -5,8 +5,8 @@
         "fg": "#fff",
         "name": {
             "en": "Metro Line 1",
-            "zh-Hans": "地铁一号线",
-            "zh-Hant": "捷運一號線",
+            "zh-Hans": "地铁1号线",
+            "zh-Hant": "捷運1號線",
             "ru": "M1"
         }
     },
@@ -16,8 +16,8 @@
         "fg": "#fff",
         "name": {
             "en": "Metro Line 2",
-            "zh-Hans": "地铁二号线",
-            "zh-Hant": "捷運二號線",
+            "zh-Hans": "地铁2号线",
+            "zh-Hant": "捷運2號線",
             "ru": "M2"
         }
     },
@@ -27,8 +27,8 @@
         "fg": "#fff",
         "name": {
             "en": "Metro Line 3",
-            "zh-Hans": "地铁三号线",
-            "zh-Hant": "捷運三號線",
+            "zh-Hans": "地铁3号线",
+            "zh-Hant": "捷運3號線",
             "ru": "M3"
         }
     }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Kyiv on behalf of DQB061204.
This should fix #616

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Metro Line 1: bg=`#e53027`, fg=`#fff`
Metro Line 2: bg=`#2385c6`, fg=`#fff`
Metro Line 3: bg=`#34b660`, fg=`#fff`