### PR TITLE
Resources: New palettes of Yekaterinburg

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1295,6 +1295,16 @@
         }
     },
     {
+        "id": "yekaterinburg",
+        "country": "RU",
+        "name": {
+            "en": "Yekaterinburg",
+            "zh-Hans": "叶卡捷琳堡",
+            "zh-Hant": "葉卡捷琳堡",
+            "ru": "Екатеринбургский"
+        }
+    },
+    {
         "id": "yevpatoria",
         "country": "UA",
         "name": {

--- a/public/resources/palettes/yekaterinburg.json
+++ b/public/resources/palettes/yekaterinburg.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "gl",
+        "colour": "#007a3d",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線",
+            "ru": "Зеленая линия"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Yekaterinburg on behalf of DQB061204.
This should fix #618

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Green Line: bg=`#007a3d`, fg=`#fff`