### PR TITLE
Resources: New palettes of Novosibirsk

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -847,6 +847,16 @@
         }
     },
     {
+        "id": "novosibirsk",
+        "country": "RU",
+        "name": {
+            "en": "Novosibirsk",
+            "zh-Hans": "新西伯利亚",
+            "zh-Hant": "新西伯利亞",
+            "ru": "Новосибирский"
+        }
+    },
+    {
         "id": "osaka",
         "country": "JP",
         "name": {

--- a/public/resources/palettes/novosibirsk.json
+++ b/public/resources/palettes/novosibirsk.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "gl",
+        "colour": "#009a47",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線",
+            "ru": "Зеленая линия"
+        }
+    },
+    {
+        "id": "rl",
+        "colour": "#dd2129",
+        "fg": "#fff",
+        "name": {
+            "en": "Red Line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線",
+            "ru": "Красная линия"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Novosibirsk on behalf of DQB061204.
This should fix #620

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Green Line: bg=`#009a47`, fg=`#fff`
Red Line: bg=`#dd2129`, fg=`#fff`