### PR TITLE
Resources: New palettes of Samara

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -973,6 +973,16 @@
         }
     },
     {
+        "id": "samara",
+        "country": "RU",
+        "name": {
+            "en": "Samara",
+            "zh-Hans": "萨马拉",
+            "zh-Hant": "薩馬拉",
+            "ru": "Самарское"
+        }
+    },
+    {
         "id": "sanfrancisco",
         "country": "US",
         "name": {

--- a/public/resources/palettes/samara.json
+++ b/public/resources/palettes/samara.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "rl",
+        "colour": "#f84a39",
+        "fg": "#fff",
+        "name": {
+            "en": "Red Line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線",
+            "ru": "Красная линия"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Samara on behalf of DQB061204.
This should fix #622

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Red Line: bg=`#f84a39`, fg=`#fff`