### PR TITLE
Resources: New palettes of Chennai

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -232,6 +232,16 @@
         }
     },
     {
+        "id": "chennai",
+        "country": "IN",
+        "name": {
+            "en": "Chennai",
+            "zh-Hans": "金奈",
+            "zh-Hant": "金奈",
+            "hi": "சென்னை"
+        }
+    },
+    {
         "id": "chongqing",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/chennai.json
+++ b/public/resources/palettes/chennai.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "bl",
+        "colour": "#00a7df",
+        "fg": "#fff",
+        "name": {
+            "en": "Blue Line",
+            "zh-Hans": "蓝线",
+            "zh-Hant": "藍線",
+            "hi": "ब्लू लाइन"
+        }
+    },
+    {
+        "id": "gl",
+        "colour": "#5ba612",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線",
+            "hi": "ग्रीन लाइन"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Chennai on behalf of DQB061204.
This should fix #624

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Blue Line: bg=`#00a7df`, fg=`#fff`
Green Line: bg=`#5ba612`, fg=`#fff`