### PR TITLE
Resources: New palettes of Lucknow

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -657,6 +657,16 @@
         }
     },
     {
+        "id": "lucknow",
+        "country": "IN",
+        "name": {
+            "en": "Lucknow",
+            "zh-Hans": "勒克瑙",
+            "zh-Hant": "勒克瑙",
+            "hi": "लखनऊ"
+        }
+    },
+    {
         "id": "luoyang",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/lucknow.json
+++ b/public/resources/palettes/lucknow.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "rl",
+        "colour": "#d90f03",
+        "fg": "#fff",
+        "name": {
+            "en": "Red Line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線",
+            "hi": "लाल रेखा"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Lucknow on behalf of DQB061204.
This should fix #626

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Red Line: bg=`#d90f03`, fg=`#fff`