### PR TITLE
Resources: New palettes of Shenyang

### DIFF
--- a/public/resources/palettes/shenyang.json
+++ b/public/resources/palettes/shenyang.json
@@ -68,5 +68,55 @@
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
         }
+    },
+    {
+        "id": "syhnt1",
+        "colour": "#ec020d",
+        "fg": "#fff",
+        "name": {
+            "en": "Hunnan Tram Line 1",
+            "zh-Hans": "浑南有轨电车1号线",
+            "zh-Hant": "渾南有軌電車1號綫"
+        }
+    },
+    {
+        "id": "syhnt2",
+        "colour": "#a5499c",
+        "fg": "#fff",
+        "name": {
+            "en": "Hunnan Tram Line 2",
+            "zh-Hans": "浑南有轨电车2号线",
+            "zh-Hant": "渾南有軌電車2號綫"
+        }
+    },
+    {
+        "id": "syhnt3",
+        "colour": "#039942",
+        "fg": "#fff",
+        "name": {
+            "en": "Hunnan Tram Line 3",
+            "zh-Hans": "浑南有轨电车3号线",
+            "zh-Hant": "渾南有軌電車3號綫"
+        }
+    },
+    {
+        "id": "syhnt4",
+        "colour": "#00a2e8",
+        "fg": "#fff",
+        "name": {
+            "en": "Hunnan Tram Line 4",
+            "zh-Hans": "浑南有轨电车4号线",
+            "zh-Hant": "渾南有軌電車4號綫"
+        }
+    },
+    {
+        "id": "syhnt5",
+        "colour": "#1f2188",
+        "fg": "#fff",
+        "name": {
+            "en": "Hunnan Tram Line 5",
+            "zh-Hans": "浑南有轨电车5号线",
+            "zh-Hant": "渾南有軌電車5號綫"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenyang on behalf of dqwfgzs.
This should fix #630

> @railmapgen/rmg-palette-resources@0.8.10 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#b63f1f`, fg=`#fff`
Line 2: bg=`#e5703a`, fg=`#fff`
Line 3: bg=`#E6669F`, fg=`#fff`
Line 4: bg=`#6E3E94`, fg=`#fff`
Line 6: bg=`#FEDC00`, fg=`#fff`
Line 9: bg=`#017cbf`, fg=`#fff`
Line 10: bg=`#62aa3c`, fg=`#fff`
Hunnan Tram Line 1: bg=`#ec020d`, fg=`#fff`
Hunnan Tram Line 2: bg=`#a5499c`, fg=`#fff`
Hunnan Tram Line 3: bg=`#039942`, fg=`#fff`
Hunnan Tram Line 4: bg=`#00a2e8`, fg=`#fff`
Hunnan Tram Line 5: bg=`#1f2188`, fg=`#fff`