### PR TITLE
Resources: New palettes of Los Angeles (South California)

### DIFF
--- a/public/resources/palettes/losangeles.json
+++ b/public/resources/palettes/losangeles.json
@@ -45,7 +45,7 @@
     },
     {
         "id": "lae",
-        "colour": "#5bc2e7",
+        "colour": "#fdba12",
         "fg": "#000",
         "name": {
             "en": "E Line",
@@ -63,17 +63,6 @@
             "zh-Hans": "K线",
             "zh-Hant": "K線",
             "ko": "K선"
-        }
-    },
-    {
-        "id": "lal",
-        "colour": "#fdb913",
-        "fg": "#000",
-        "name": {
-            "en": "L Line",
-            "zh-Hans": "L线",
-            "zh-Hant": "L線",
-            "ko": "L선"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Los Angeles (South California) on behalf of aaronyz2007.
This should fix #634

> @railmapgen/rmg-palette-resources@0.8.11 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

A Line: bg=`#0072bc`, fg=`#fff`
B Line: bg=`#e3131b`, fg=`#fff`
C Line: bg=`#58a738`, fg=`#fff`
D Line: bg=`#a05da5`, fg=`#fff`
E Line: bg=`#fdba12`, fg=`#000`
K Line: bg=`#e96bb0`, fg=`#000`
G Line: bg=`#fc4c02`, fg=`#fff`
J Line: bg=`#adb8bf`, fg=`#000`
Antelope Valley Line: bg=`#1c9d03`, fg=`#fff`
Inland Empire-Orange County Line: bg=`#bd295a`, fg=`#fff`
Orange County Line: bg=`#ff7600`, fg=`#fff`
Riverside Line: bg=`#682e86`, fg=`#fff`
San Bernardino Line: bg=`#a32136`, fg=`#fff`
Ventura County Line: bg=`#f6a704`, fg=`#fff`
91/Perris Valley Line: bg=`#0071ce`, fg=`#fff`