### PR TITLE
Resources: New palettes of Tokyo (Greater Tokyo Area)

### DIFF
--- a/public/resources/palettes/tokyo.json
+++ b/public/resources/palettes/tokyo.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "g",
-        "colour": "#ff9500",
+        "colour": "#f9a328",
         "fg": "#fff",
         "name": {
             "en": "Ginza Line (G)",
@@ -12,7 +12,7 @@
     },
     {
         "id": "m",
-        "colour": "#f62e36",
+        "colour": "#ee2628",
         "fg": "#fff",
         "name": {
             "en": "Marunouchi Line (M)",
@@ -23,7 +23,7 @@
     },
     {
         "id": "h",
-        "colour": "#b5b5ac",
+        "colour": "#c7beb3",
         "fg": "#fff",
         "name": {
             "en": "Hibiya Line (H)",
@@ -34,7 +34,7 @@
     },
     {
         "id": "t",
-        "colour": "#009bbf",
+        "colour": "#00afef",
         "fg": "#fff",
         "name": {
             "en": "Tōzai Line (T)",
@@ -45,7 +45,7 @@
     },
     {
         "id": "c",
-        "colour": "#00bb85",
+        "colour": "#1bb267",
         "fg": "#fff",
         "name": {
             "en": "Chiyoda Line (C)",
@@ -56,7 +56,7 @@
     },
     {
         "id": "y",
-        "colour": "#c1a470",
+        "colour": "#d1a662",
         "fg": "#fff",
         "name": {
             "en": "Yūrakuchō Line (Y)",
@@ -67,7 +67,7 @@
     },
     {
         "id": "z",
-        "colour": "#8f76d6",
+        "colour": "#8c7dba",
         "fg": "#fff",
         "name": {
             "en": "Hanzōmon Line (Z)",
@@ -78,7 +78,7 @@
     },
     {
         "id": "n",
-        "colour": "#00ac9b",
+        "colour": "#02b69b",
         "fg": "#fff",
         "name": {
             "en": "Namboku Line (N)",
@@ -100,7 +100,7 @@
     },
     {
         "id": "a",
-        "colour": "#ec6e65",
+        "colour": "#ef463c",
         "fg": "#fff",
         "name": {
             "en": "Asakusa Line (A)",
@@ -111,7 +111,7 @@
     },
     {
         "id": "i",
-        "colour": "#006ab8",
+        "colour": "#0090bc",
         "fg": "#fff",
         "name": {
             "en": "Mita Line (I)",
@@ -122,7 +122,7 @@
     },
     {
         "id": "s",
-        "colour": "#b0bf1e",
+        "colour": "#abba41",
         "fg": "#fff",
         "name": {
             "en": "Shinjuku Line (S)",
@@ -133,7 +133,7 @@
     },
     {
         "id": "o",
-        "colour": "#ce045b",
+        "colour": "#ce1c64",
         "fg": "#fff",
         "name": {
             "en": "Ōedo Line (O)",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Tokyo (Greater Tokyo Area) on behalf of LittleLing03.
This should fix #637

> @railmapgen/rmg-palette-resources@0.8.11 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Ginza Line (G): bg=`#f9a328`, fg=`#fff`
Marunouchi Line (M): bg=`#ee2628`, fg=`#fff`
Hibiya Line (H): bg=`#c7beb3`, fg=`#fff`
Tōzai Line (T): bg=`#00afef`, fg=`#fff`
Chiyoda Line (C): bg=`#1bb267`, fg=`#fff`
Yūrakuchō Line (Y): bg=`#d1a662`, fg=`#fff`
Hanzōmon Line (Z): bg=`#8c7dba`, fg=`#fff`
Namboku Line (N): bg=`#02b69b`, fg=`#fff`
Fukutoshin Line (F): bg=`#9c5e31`, fg=`#fff`
Asakusa Line (A): bg=`#ef463c`, fg=`#fff`
Mita Line (I): bg=`#0090bc`, fg=`#fff`
Shinjuku Line (S): bg=`#abba41`, fg=`#fff`
Ōedo Line (O): bg=`#ce1c64`, fg=`#fff`
Yamanote Line (JY): bg=`#B1CB39`, fg=`#fff`
Keihin-Tōhoku Line/Negishi Line (JK): bg=`#1DAED1`, fg=`#fff`
Chūō Line/Sōbu Line (Local) (JB): bg=`#F2D01F`, fg=`#fff`
Chūō Line (Rapid)/Chūō Line/Ōme Line/Itsukaichi Line (JC): bg=`#DD6935`, fg=`#fff`
Yokosuka Line/Sōbu Line (Rapid)/Sōbu Line/Narita Line (JO): bg=`#1069B4`, fg=`#fff`
Utsunomiya Line/Takasaki Line (JU): bg=`#F18E41`, fg=`#fff`
Tōkaidō Line/Itō Line (JT): bg=`#F0862B`, fg=`#fff`
Saikyō Line (JA): bg=`#14A676`, fg=`#fff`
Shōnan-Shinjuku Line (JS): bg=`#DB2027`, fg=`#fff`
Jōban Line (Rapid) (JJ): bg=`#1DAF7E`, fg=`#fff`
Jōban Line (Local) (JL): bg=`#868587`, fg=`#fff`
Keiyō Line (JE): bg=`#D01827`, fg=`#fff`
Yokohama Line (JH): bg=`#B1CB39`, fg=`#fff`
Musashino Line (JM): bg=`#EB5A28`, fg=`#fff`
Nambu Line (JN): bg=`#F2D01F`, fg=`#fff`
Tsurumi Line (JI): bg=`#F2D01F`, fg=`#fff`
Tokyo Monorail Haneda Airport Line (MO): bg=`#26326A`, fg=`#fff`
Yokohama Municipal Subway Blue Line (B): bg=`#2F56A5`, fg=`#fff`
Yokohama Municipal Subway Green Line (G): bg=`#28846E`, fg=`#fff`
Tōkyū Tōyoko Line (TY): bg=`#DA0042`, fg=`#fff`
Tōkyū Meguro Line (MG): bg=`#009CD3`, fg=`#fff`
Tōkyū Den-en-toshi Line (DT): bg=`#00AA8D`, fg=`#fff`
Tōkyū Ōimachi Line (OM): bg=`#F18C43`, fg=`#fff`
Tōkyū Ikegami Line (IK): bg=`#EE86A8`, fg=`#fff`
Tōkyū Tamagawa Line (TM): bg=`#AE0079`, fg=`#fff`
Kodomonokuni Line (KD): bg=`#0071BE`, fg=`#fff`
Tōkyū Setagaya Line (SG): bg=`#FCC800`, fg=`#fff`
Seibu Ikebukuro Line (SI): bg=`#EF7A00`, fg=`#fff`
Seibu Shinjuku Line (SS): bg=`#00A6BF`, fg=`#fff`
Seibu Kokubunji Line (SK): bg=`#38b35c`, fg=`#fff`
Seibu Tamagawa Line (SW): bg=`#f17c24`, fg=`#fff`
Seibu Tamako Line (ST): bg=`#f7aa2c`, fg=`#fff`
Seibu Yamaguchi Line (SY): bg=`#ec4840`, fg=`#fff`
Tōbu Skytree Line (TS): bg=`#006CBA`, fg=`#fff`
Tōbu Isesaki Line (TI): bg=`#E61919`, fg=`#fff`
Tōbu Nikkō Line (TN): bg=`#F5A200`, fg=`#fff`
Tōbu Urban Park Line (TD): bg=`#40B4E5`, fg=`#fff`
Tōbu Tōjō Line (TJ): bg=`#00428E`, fg=`#fff`
Keisei Main Line (KS): bg=`#005AAA`, fg=`#fff`
Keisei Narita Airport Line (KS): bg=`#FF8620`, fg=`#fff`
Shin-Keisei Line (SL): bg=`#EF59A1`, fg=`#fff`
Hokusō Line (HS): bg=`#00bdf2`, fg=`#fff`
Shibayama Railway Line (SR): bg=`#00A650`, fg=`#fff`
Odakyū Lines (OH/OE/OT): bg=`#0085CE`, fg=`#fff`
Keiō Line (KO): bg=`#D5007F`, fg=`#fff`
Keiō Inokashira Line (IN): bg=`#103675`, fg=`#fff`
Keikyū Main Line (KK): bg=`#00BFFF`, fg=`#fff`
Sōtetsu Main Line (SO): bg=`#0071C1`, fg=`#fff`
Rinkai Line (R): bg=`#00418e`, fg=`#fff`
New Transit Yurikamome (U): bg=`#1662B8`, fg=`#fff`
Tokyo Sakura Tram (SA): bg=`#d75b80`, fg=`#fff`
Nippori-Toneri Liner (NT): bg=`#D53A77`, fg=`#fff`
Minatomirai Line (MM): bg=`#19559F`, fg=`#fff`
Enoshima Dentetsu Line (EN): bg=`#f6be18`, fg=`#fff`
Tōyō Rapid Railway Line (TR): bg=`#5AB65C`, fg=`#fff`
Saitama Rapid Railway Line (SR): bg=`#3564AF`, fg=`#fff`
Tama Toshi Monorail Line: bg=`#27625E`, fg=`#fff`
Ina Line (NS): bg=`#18A698`, fg=`#fff`
Chōshi Electric Railway Line (CD): bg=`#a52a2a`, fg=`#fff`
Chiba Urban Monorail (CM): bg=`#2843ba`, fg=`#fff`