### PR TITLE
Resources: New palettes of Mexico City

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -722,6 +722,16 @@
         }
     },
     {
+        "id": "mexicocity",
+        "country": "MX",
+        "name": {
+            "en": "Mexico City",
+            "zh-Hans": "墨西哥城",
+            "zh-Hant": "墨西哥城",
+            "es": "Ciudad de México"
+        }
+    },
+    {
         "id": "milan",
         "country": "IT",
         "name": {

--- a/public/resources/palettes/mexicocity.json
+++ b/public/resources/palettes/mexicocity.json
@@ -1,0 +1,145 @@
+[
+    {
+        "id": "l1",
+        "colour": "#ed699b",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線",
+            "es": "Línea 1"
+        }
+    },
+    {
+        "id": "l2",
+        "colour": "#007bc1",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線",
+            "es": "Línea 2"
+        }
+    },
+    {
+        "id": "l3",
+        "colour": "#bfad1d",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線",
+            "es": "Línea 3"
+        }
+    },
+    {
+        "id": "l4",
+        "colour": "#7bc7ba",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "zh-Hans": "4号线",
+            "zh-Hant": "4號線",
+            "es": "Línea 4"
+        }
+    },
+    {
+        "id": "l5",
+        "colour": "#ffdb25",
+        "fg": "#000",
+        "name": {
+            "en": "Line 5",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號線",
+            "es": "Línea 5"
+        }
+    },
+    {
+        "id": "l6",
+        "colour": "#e82428",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號線",
+            "es": "Línea 6"
+        }
+    },
+    {
+        "id": "l7",
+        "colour": "#f17c2f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 7",
+            "zh-Hans": "7号线",
+            "zh-Hant": "7號線",
+            "es": "Línea 7"
+        }
+    },
+    {
+        "id": "l8",
+        "colour": "#00a263",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號線",
+            "es": "Línea 8"
+        }
+    },
+    {
+        "id": "l9",
+        "colour": "#581c00",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 9",
+            "zh-Hans": "9号线",
+            "zh-Hant": "9號線",
+            "es": "Línea 9"
+        }
+    },
+    {
+        "id": "la",
+        "colour": "#8f248e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line A",
+            "zh-Hans": "A线",
+            "zh-Hant": "A線",
+            "es": "Línea A"
+        }
+    },
+    {
+        "id": "lb1",
+        "colour": "#018752",
+        "fg": "#fff",
+        "name": {
+            "en": "Line B",
+            "zh-Hans": "B线（颜色1）",
+            "zh-Hant": "B線（顏色1）",
+            "es": "Línea B"
+        }
+    },
+    {
+        "id": "lb2",
+        "colour": "#bebfc1",
+        "fg": "#000",
+        "name": {
+            "en": "Line B",
+            "zh-Hans": "B线（颜色2）",
+            "zh-Hant": "B線（顏色2）",
+            "es": "Línea B"
+        }
+    },
+    {
+        "id": "l12",
+        "colour": "#b49c4e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 12",
+            "zh-Hans": "12号线",
+            "zh-Hant": "12號線",
+            "es": "Línea 12"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Mexico City on behalf of DQB061204.
This should fix #610

> @railmapgen/rmg-palette-resources@0.8.11 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#ed699b`, fg=`#fff`
Line 2: bg=`#007bc1`, fg=`#fff`
Line 3: bg=`#bfad1d`, fg=`#fff`
Line 4: bg=`#7bc7ba`, fg=`#fff`
Line 5: bg=`#ffdb25`, fg=`#000`
Line 6: bg=`#e82428`, fg=`#fff`
Line 7: bg=`#f17c2f`, fg=`#fff`
Line 8: bg=`#00a263`, fg=`#fff`
Line 9: bg=`#581c00`, fg=`#fff`
Line A: bg=`#8f248e`, fg=`#fff`
Line B: bg=`#018752`, fg=`#fff`
Line B: bg=`#bebfc1`, fg=`#000`
Line 12: bg=`#b49c4e`, fg=`#fff`