### PR TITLE
Resources: New palettes of Tianjin

### DIFF
--- a/public/resources/palettes/tianjin.json
+++ b/public/resources/palettes/tianjin.json
@@ -1,266 +1,292 @@
 [
     {
         "id": "tj1",
+        "colour": "#bd0016",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#bd0016"
+        }
     },
     {
         "id": "tj2",
+        "colour": "#ece114",
+        "fg": "#000",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#ece114",
-        "fg": "#000"
+        }
     },
     {
         "id": "tj3",
+        "colour": "#128bbe",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#128bbe"
+        }
     },
     {
         "id": "tj4",
+        "colour": "#1c7736",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#1c7736"
+        }
     },
     {
         "id": "tj5",
+        "colour": "#fb6f14",
+        "fg": "#fff",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
             "zh-Hant": "5號線"
-        },
-        "colour": "#fb6f14"
+        }
     },
     {
         "id": "tj6",
+        "colour": "#9f216f",
+        "fg": "#fff",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
             "zh-Hant": "6號線"
-        },
-        "colour": "#9f216f"
+        }
     },
     {
         "id": "tj7",
+        "colour": "#b17833",
+        "fg": "#fff",
         "name": {
             "en": "Line 7",
             "zh-Hans": "7号线",
             "zh-Hant": "7號線"
-        },
-        "colour": "#b17833"
+        }
     },
     {
         "id": "tj8",
+        "colour": "#602e7c",
+        "fg": "#fff",
         "name": {
             "en": "Line 8",
             "zh-Hans": "8号线",
             "zh-Hant": "8號線"
-        },
-        "colour": "#602e7c"
+        }
     },
     {
         "id": "tj9",
+        "colour": "#063a91",
+        "fg": "#fff",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
             "zh-Hant": "9號線"
-        },
-        "colour": "#063a91"
+        }
     },
     {
         "id": "tj10",
+        "colour": "#b9cf09",
+        "fg": "#fff",
         "name": {
             "en": "Line 10",
             "zh-Hans": "10号线",
             "zh-Hant": "10號線"
-        },
-        "colour": "#b9cf09",
-        "fg": "#000"
+        }
     },
     {
         "id": "tj11",
+        "colour": "#ed0066",
+        "fg": "#fff",
         "name": {
             "en": "Line 11",
             "zh-Hans": "11号线",
             "zh-Hant": "11號線"
-        },
-        "colour": "#ed0066"
+        }
     },
     {
         "id": "tj12",
+        "colour": "#3b008c",
+        "fg": "#fff",
         "name": {
             "en": "Line 12",
             "zh-Hans": "12号线",
             "zh-Hant": "12號線"
-        },
-        "colour": "#3b008c"
+        }
     },
     {
         "id": "tj13",
+        "colour": "#def148",
+        "fg": "#000",
         "name": {
             "en": "Line 13",
             "zh-Hans": "13号线",
             "zh-Hant": "13號線"
-        },
-        "colour": "#def148",
-        "fg": "#000"
+        }
     },
     {
         "id": "b1",
+        "colour": "#e13c4b",
+        "fg": "#fff",
         "name": {
             "en": "Line B1",
             "zh-Hans": "B1线",
             "zh-Hant": "B1線"
-        },
-        "colour": "#e13c4b"
+        }
     },
     {
         "id": "b2",
+        "colour": "#fbf053",
+        "fg": "#fff",
         "name": {
             "en": "Line B2",
             "zh-Hans": "B2线",
             "zh-Hant": "B2線"
-        },
-        "colour": "#fbf053"
+        }
     },
     {
         "id": "b3",
+        "colour": "#75c2c9",
+        "fg": "#fff",
         "name": {
             "en": "Line B3",
             "zh-Hans": "B3线",
             "zh-Hant": "B3線"
-        },
-        "colour": "#75c2c9"
+        }
     },
     {
         "id": "b4",
+        "colour": "#5cb35d",
+        "fg": "#fff",
         "name": {
             "en": "Line B4",
             "zh-Hans": "B4线",
             "zh-Hant": "B4線"
-        },
-        "colour": "#5cb35d"
+        }
     },
     {
         "id": "b5",
+        "colour": "#f6ac5b",
+        "fg": "#fff",
         "name": {
             "en": "Line B5",
             "zh-Hans": "B5线",
             "zh-Hant": "B5線"
-        },
-        "colour": "#f6ac5b"
+        }
     },
     {
         "id": "b6",
+        "colour": "#eb76bd",
+        "fg": "#fff",
         "name": {
             "en": "Line B6",
             "zh-Hans": "B6线",
             "zh-Hant": "B6線"
-        },
-        "colour": "#eb76bd"
+        }
     },
     {
         "id": "b7",
+        "colour": "#d8ad71",
+        "fg": "#fff",
         "name": {
             "en": "Line B7",
             "zh-Hans": "B7线",
             "zh-Hant": "B7線"
-        },
-        "colour": "#d8ad71"
+        }
     },
     {
         "id": "c1",
+        "colour": "#d1ce69",
+        "fg": "#fff",
         "name": {
             "en": "Line C1",
             "zh-Hans": "C1线",
             "zh-Hant": "C1線"
-        },
-        "colour": "#d1ce69"
+        }
     },
     {
         "id": "c2",
+        "colour": "#dd8dae",
+        "fg": "#fff",
         "name": {
             "en": "Line C2",
             "zh-Hans": "C2线",
             "zh-Hant": "C2線"
-        },
-        "colour": "#dd8dae"
+        }
     },
     {
         "id": "c3",
+        "colour": "#769c62",
+        "fg": "#fff",
         "name": {
             "en": "Line C3",
             "zh-Hans": "C3线",
             "zh-Hant": "C3線"
-        },
-        "colour": "#769c62"
+        }
     },
     {
         "id": "c4",
+        "colour": "#5c480f",
+        "fg": "#fff",
         "name": {
             "en": "Line C4",
             "zh-Hans": "C4线",
             "zh-Hant": "C4線"
-        },
-        "colour": "#5c480f"
+        }
     },
     {
         "id": "z1",
+        "colour": "#626da7",
+        "fg": "#fff",
         "name": {
             "en": "Line Z1",
             "zh-Hans": "Z1线",
             "zh-Hant": "Z1線"
-        },
-        "colour": "#626da7"
+        }
     },
     {
         "id": "z2",
+        "colour": "#1d6b9a",
+        "fg": "#fff",
         "name": {
             "en": "Line Z2",
             "zh-Hans": "Z2线",
             "zh-Hant": "Z2線"
-        },
-        "colour": "#1d6b9a"
+        }
     },
     {
         "id": "z3",
+        "colour": "#bd5832",
+        "fg": "#fff",
         "name": {
             "en": "Line Z3",
             "zh-Hans": "Z3线",
             "zh-Hant": "Z3線"
-        },
-        "colour": "#bd5832"
+        }
     },
     {
         "id": "z4",
+        "colour": "#9574ac",
+        "fg": "#fff",
         "name": {
             "en": "Line Z4",
             "zh-Hans": "Z4线",
             "zh-Hant": "Z4線"
-        },
-        "colour": "#9574ac"
+        }
     },
     {
         "id": "t1",
+        "colour": "#8FC31F",
+        "fg": "#fff",
         "name": {
             "en": "TEDA Modern Guided Rail Tram",
             "zh-Hans": "导轨1号线",
             "zh-Hant": "導軌1號線"
-        },
-        "colour": "#8FC31F"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Tianjin on behalf of WAHX-1453.
This should fix #640

> @railmapgen/rmg-palette-resources@0.8.11 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#bd0016`, fg=`#fff`
Line 2: bg=`#ece114`, fg=`#000`
Line 3: bg=`#128bbe`, fg=`#fff`
Line 4: bg=`#1c7736`, fg=`#fff`
Line 5: bg=`#fb6f14`, fg=`#fff`
Line 6: bg=`#9f216f`, fg=`#fff`
Line 7: bg=`#b17833`, fg=`#fff`
Line 8: bg=`#602e7c`, fg=`#fff`
Line 9: bg=`#063a91`, fg=`#fff`
Line 10: bg=`#b9cf09`, fg=`#fff`
Line 11: bg=`#ed0066`, fg=`#fff`
Line 12: bg=`#3b008c`, fg=`#fff`
Line 13: bg=`#def148`, fg=`#000`
Line B1: bg=`#e13c4b`, fg=`#fff`
Line B2: bg=`#fbf053`, fg=`#fff`
Line B3: bg=`#75c2c9`, fg=`#fff`
Line B4: bg=`#5cb35d`, fg=`#fff`
Line B5: bg=`#f6ac5b`, fg=`#fff`
Line B6: bg=`#eb76bd`, fg=`#fff`
Line B7: bg=`#d8ad71`, fg=`#fff`
Line C1: bg=`#d1ce69`, fg=`#fff`
Line C2: bg=`#dd8dae`, fg=`#fff`
Line C3: bg=`#769c62`, fg=`#fff`
Line C4: bg=`#5c480f`, fg=`#fff`
Line Z1: bg=`#626da7`, fg=`#fff`
Line Z2: bg=`#1d6b9a`, fg=`#fff`
Line Z3: bg=`#bd5832`, fg=`#fff`
Line Z4: bg=`#9574ac`, fg=`#fff`
TEDA Modern Guided Rail Tram: bg=`#8FC31F`, fg=`#fff`