### PR TITLE
Resources: New palettes of Hong Kong

### DIFF
--- a/public/resources/palettes/hongkong.json
+++ b/public/resources/palettes/hongkong.json
@@ -1,308 +1,352 @@
 [
     {
         "id": "twl",
+        "colour": "#E2231A",
+        "fg": "#fff",
         "name": {
             "en": "Tsuen Wan Line",
             "zh-Hans": "荃湾线",
             "zh-Hant": "荃灣綫"
-        },
-        "colour": "#E2231A"
+        }
     },
     {
         "id": "ktl",
+        "colour": "#00AF41",
+        "fg": "#fff",
         "name": {
             "en": "Kwun Tong Line",
             "zh-Hans": "观塘线",
             "zh-Hant": "觀塘綫"
-        },
-        "colour": "#00AF41"
+        }
     },
     {
         "id": "isl",
+        "colour": "#0071CE",
+        "fg": "#fff",
         "name": {
             "en": "Island Line",
             "zh-Hans": "港岛线",
             "zh-Hant": "港島綫"
-        },
-        "colour": "#0071CE"
+        }
     },
     {
         "id": "tkl",
+        "colour": "#A35EB5",
+        "fg": "#fff",
         "name": {
             "en": "Tseung Kwan O Line",
             "zh-Hans": "将军澳线",
             "zh-Hant": "將軍澳綫"
-        },
-        "colour": "#A35EB5"
+        }
     },
     {
         "id": "tcl",
+        "colour": "#F38B00",
+        "fg": "#fff",
         "name": {
             "en": "Tung Chung Line",
             "zh-Hans": "东涌线",
             "zh-Hant": "東涌綫"
-        },
-        "colour": "#F38B00"
+        }
     },
     {
         "id": "drl",
+        "colour": "#E777CB",
+        "fg": "#fff",
         "name": {
             "en": "Disney Resort Line",
             "zh-Hans": "迪士尼线",
             "zh-Hant": "迪士尼綫"
-        },
-        "colour": "#E777CB"
+        }
     },
     {
         "id": "ael",
+        "colour": "#007078",
+        "fg": "#fff",
         "name": {
             "en": "Airport Express",
             "zh-Hans": "机场快线",
             "zh-Hant": "機場快綫"
-        },
-        "colour": "#007078"
+        }
     },
     {
         "id": "sile",
+        "colour": "#B6BD00",
+        "fg": "#fff",
         "name": {
             "en": "South Island Line (East)",
             "zh-Hans": "南港岛线（东段）",
             "zh-Hant": "南港島綫（東段）"
-        },
-        "colour": "#B6BD00"
+        }
     },
     {
         "id": "silw",
+        "colour": "#9182C2",
+        "fg": "#fff",
         "name": {
             "en": "South Island Line (West)",
             "zh-Hans": "南港岛线（西段）",
             "zh-Hant": "南港島綫（西段）"
-        },
-        "colour": "#9182C2"
+        }
     },
     {
         "id": "ekl",
+        "colour": "#00FF00",
+        "fg": "#fff",
         "name": {
             "en": "East Kowloon Line",
             "zh-Hans": "东九龙线",
             "zh-Hant": "東九龍綫"
-        },
-        "colour": "#00FF00"
+        }
     },
     {
         "id": "eal",
+        "colour": "#61B4E4",
+        "fg": "#fff",
         "name": {
             "en": "East Rail Line",
             "zh-Hans": "东铁线",
             "zh-Hant": "東鐵綫"
-        },
-        "colour": "#61B4E4"
+        }
     },
     {
         "id": "mol",
+        "colour": "#9A3820",
+        "fg": "#fff",
         "name": {
             "en": "Tuen Ma Line",
             "zh-Hans": "屯马线",
             "zh-Hant": "屯馬綫"
-        },
-        "colour": "#9A3820"
+        }
     },
     {
         "id": "nol",
+        "colour": "#FF0066",
+        "fg": "#fff",
         "name": {
             "en": "Northern Link",
             "zh-Hans": "北环线",
             "zh-Hant": "北環綫"
-        },
-        "colour": "#FF0066"
+        }
     },
     {
         "id": "lrl",
+        "colour": "#CD9700",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail",
             "zh-Hans": "轻铁",
             "zh-Hant": "輕鐵"
-        },
-        "colour": "#CD9700"
+        }
     },
     {
         "id": "lrl505",
+        "colour": "#DB1F26",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 505",
             "zh-Hans": "轻铁505线",
             "zh-Hant": "輕鐵505綫"
-        },
-        "colour": "#DB1F26"
+        }
     },
     {
         "id": "lrl507",
+        "colour": "#00A650",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 507",
             "zh-Hans": "轻铁507线",
             "zh-Hant": "輕鐵507綫"
-        },
-        "colour": "#00A650"
+        }
     },
     {
         "id": "lrl610",
+        "colour": "#431115",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 610",
             "zh-Hans": "轻铁610线",
             "zh-Hant": "輕鐵610綫"
-        },
-        "colour": "#431115"
+        }
     },
     {
         "id": "lrl614",
+        "colour": "#4DC6F4",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 614",
             "zh-Hans": "轻铁614线",
             "zh-Hant": "輕鐵614綫"
-        },
-        "colour": "#4DC6F4"
+        }
     },
     {
         "id": "lrl614p",
+        "colour": "#F46989",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 614P",
             "zh-Hans": "轻铁614P线",
             "zh-Hant": "輕鐵614P綫"
-        },
-        "colour": "#F46989"
+        }
     },
     {
         "id": "lrl615",
+        "colour": "#FDDD04",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 615",
             "zh-Hans": "轻铁615线",
             "zh-Hant": "輕鐵615綫"
-        },
-        "colour": "#FDDD04"
+        }
     },
     {
         "id": "lrl615p",
+        "colour": "#215483",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 615P",
             "zh-Hans": "轻铁615P线",
             "zh-Hant": "輕鐵615P綫"
-        },
-        "colour": "#215483"
+        }
     },
     {
         "id": "lrl705",
+        "colour": "#64C542",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 705",
             "zh-Hans": "轻铁705线",
             "zh-Hant": "輕鐵705綫"
-        },
-        "colour": "#64C542"
+        }
     },
     {
         "id": "lrl706",
+        "colour": "#B365B9",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 706",
             "zh-Hans": "轻铁706线",
             "zh-Hant": "輕鐵706綫"
-        },
-        "colour": "#B365B9"
+        }
     },
     {
         "id": "lrl751",
+        "colour": "#F47216",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 751",
             "zh-Hans": "轻铁751线",
             "zh-Hant": "輕鐵751綫"
-        },
-        "colour": "#F47216"
+        }
     },
     {
         "id": "lrl761",
+        "colour": "#672290",
+        "fg": "#fff",
         "name": {
             "en": "Light Rail Route 761/761P",
             "zh-Hans": "轻铁761/761P线",
             "zh-Hant": "輕鐵761/761P綫"
-        },
-        "colour": "#672290"
+        }
     },
     {
         "id": "efls",
+        "colour": "#000000",
+        "fg": "#fff",
         "name": {
             "en": "Environmentally Friendly Linkage System",
             "zh-Hans": "环保连接系统",
             "zh-Hant": "環保連接系統"
-        },
-        "colour": "#000000"
+        }
     },
     {
         "id": "hsr",
+        "colour": "#9D968D",
+        "fg": "#fff",
         "name": {
             "en": "High Speed Rail",
             "zh-Hans": "高速铁路",
             "zh-Hant": "高速鐵路"
-        },
-        "colour": "#9D968D"
+        }
     },
     {
         "id": "np360",
+        "colour": "#94989A",
+        "fg": "#fff",
         "name": {
             "en": "Ngong Ping 360",
             "zh-Hans": "昂坪360",
             "zh-Hant": "昂坪360"
-        },
-        "colour": "#94989A"
+        }
     },
     {
         "id": "tramways",
+        "colour": "#007549",
+        "fg": "#fff",
         "name": {
             "en": "Hong Kong Tramways",
             "zh-Hans": "香港电车",
             "zh-Hant": "香港電車"
-        },
-        "colour": "#007549"
+        }
     },
     {
         "id": "ealkcr",
+        "colour": "#005DA0",
+        "fg": "#fff",
         "name": {
             "en": "KCR East Rail",
             "zh-Hans": "九广东铁",
             "zh-Hant": "九廣東鐵"
-        },
-        "colour": "#005DA0"
+        }
     },
     {
         "id": "wrlkcr",
+        "colour": "#AC2571",
+        "fg": "#fff",
         "name": {
             "en": "KCR West Rail",
             "zh-Hans": "九广西铁",
             "zh-Hant": "九廣西鐵"
-        },
-        "colour": "#AC2571"
+        }
     },
     {
         "id": "molkcr",
+        "colour": "#761E10",
+        "fg": "#fff",
         "name": {
             "en": "Ma On Shan Rail",
             "zh-Hans": "九广马铁",
             "zh-Hant": "九廣馬鐵"
-        },
-        "colour": "#761E10"
+        }
     },
     {
         "id": "lrlkcr",
+        "colour": "#FD722D",
+        "fg": "#fff",
         "name": {
             "en": "KCR Light Rail",
             "zh-Hans": "九广轻铁",
             "zh-Hant": "九廣輕鐵"
-        },
-        "colour": "#FD722D"
+        }
     },
     {
         "id": "wrl",
+        "colour": "#B6008D",
+        "fg": "#fff",
         "name": {
             "en": "West Rail Line",
             "zh-Hans": "西铁线",
             "zh-Hant": "西鐵綫"
-        },
-        "colour": "#B6008D"
+        }
+    },
+    {
+        "id": "ttlink",
+        "colour": "#47ff97",
+        "fg": "#fff",
+        "name": {
+            "en": "Tuen Mun to Tsuen Wan Link",
+            "zh-Hans": "屯荃铁路",
+            "zh-Hant": "屯荃鐵路"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Hong Kong on behalf of benho7599.
This should fix #642

> @railmapgen/rmg-palette-resources@0.8.12 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Tsuen Wan Line: bg=`#E2231A`, fg=`#fff`
Kwun Tong Line: bg=`#00AF41`, fg=`#fff`
Island Line: bg=`#0071CE`, fg=`#fff`
Tseung Kwan O Line: bg=`#A35EB5`, fg=`#fff`
Tung Chung Line: bg=`#F38B00`, fg=`#fff`
Disney Resort Line: bg=`#E777CB`, fg=`#fff`
Airport Express: bg=`#007078`, fg=`#fff`
South Island Line (East): bg=`#B6BD00`, fg=`#fff`
South Island Line (West): bg=`#9182C2`, fg=`#fff`
East Kowloon Line: bg=`#00FF00`, fg=`#fff`
East Rail Line: bg=`#61B4E4`, fg=`#fff`
Tuen Ma Line: bg=`#9A3820`, fg=`#fff`
Northern Link: bg=`#FF0066`, fg=`#fff`
Light Rail: bg=`#CD9700`, fg=`#fff`
Light Rail Route 505: bg=`#DB1F26`, fg=`#fff`
Light Rail Route 507: bg=`#00A650`, fg=`#fff`
Light Rail Route 610: bg=`#431115`, fg=`#fff`
Light Rail Route 614: bg=`#4DC6F4`, fg=`#fff`
Light Rail Route 614P: bg=`#F46989`, fg=`#fff`
Light Rail Route 615: bg=`#FDDD04`, fg=`#fff`
Light Rail Route 615P: bg=`#215483`, fg=`#fff`
Light Rail Route 705: bg=`#64C542`, fg=`#fff`
Light Rail Route 706: bg=`#B365B9`, fg=`#fff`
Light Rail Route 751: bg=`#F47216`, fg=`#fff`
Light Rail Route 761/761P: bg=`#672290`, fg=`#fff`
Environmentally Friendly Linkage System: bg=`#000000`, fg=`#fff`
High Speed Rail: bg=`#9D968D`, fg=`#fff`
Ngong Ping 360: bg=`#94989A`, fg=`#fff`
Hong Kong Tramways: bg=`#007549`, fg=`#fff`
KCR East Rail: bg=`#005DA0`, fg=`#fff`
KCR West Rail: bg=`#AC2571`, fg=`#fff`
Ma On Shan Rail: bg=`#761E10`, fg=`#fff`
KCR Light Rail: bg=`#FD722D`, fg=`#fff`
West Rail Line: bg=`#B6008D`, fg=`#fff`
Tuen Mun to Tsuen Wan Link: bg=`#47ff97`, fg=`#fff`