### PR TITLE
Resources: New palettes of Wuhan

### DIFF
--- a/public/resources/palettes/wuhan.json
+++ b/public/resources/palettes/wuhan.json
@@ -31,8 +31,8 @@
     },
     {
         "id": "wh4",
-        "colour": "#8EC720",
-        "fg": "#fff",
+        "colour": "#00ff00",
+        "fg": "#000",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
@@ -41,7 +41,7 @@
     },
     {
         "id": "wh5",
-        "colour": "#a62e37",
+        "colour": "#a62c00",
         "fg": "#fff",
         "name": {
             "en": "Line 5",
@@ -71,8 +71,8 @@
     },
     {
         "id": "wh8",
-        "colour": "#98ACAB",
-        "fg": "#fff",
+        "colour": "#a8ffff",
+        "fg": "#000",
         "name": {
             "en": "Line 8",
             "zh-Hans": "8号线",
@@ -102,7 +102,7 @@
     {
         "id": "wh11",
         "colour": "#F2CF01",
-        "fg": "#fff",
+        "fg": "#000",
         "name": {
             "en": "Line 11",
             "zh-Hans": "11号线",
@@ -111,11 +111,11 @@
     },
     {
         "id": "wh12",
-        "colour": "#00A3E9",
-        "fg": "#fff",
+        "colour": "#00ffff",
+        "fg": "#000",
         "name": {
             "en": "Line 12",
-            "zh-Hans": "12号线",
+            "zh-Hans": "新干樱雪环线",
             "zh-Hant": "12號線"
         }
     },
@@ -145,7 +145,7 @@
         "fg": "#fff",
         "name": {
             "en": "Line 16",
-            "zh-Hans": "16号线",
+            "zh-Hans": "莹雪线",
             "zh-Hant": "16號線"
         }
     },
@@ -155,8 +155,53 @@
         "fg": "#fff",
         "name": {
             "en": "Line 21",
-            "zh-Hans": "21号线",
+            "zh-Hans": "阳逻线",
             "zh-Hant": "21號線"
+        }
+    },
+    {
+        "id": "wh19",
+        "colour": "#00ffb3",
+        "fg": "#000",
+        "name": {
+            "en": "Line 19",
+            "zh-Hans": "19号线"
+        }
+    },
+    {
+        "id": "wh17",
+        "colour": "#ffb0b0",
+        "fg": "#000",
+        "name": {
+            "en": "Line 17",
+            "zh-Hans": "刘莹线"
+        }
+    },
+    {
+        "id": "wh43",
+        "colour": "#0000ff",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 43",
+            "zh-Hans": "新仓线"
+        }
+    },
+    {
+        "id": "wh47",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 47",
+            "zh-Hans": "前川线"
+        }
+    },
+    {
+        "id": "whQ2",
+        "colour": "#388fc9",
+        "fg": "#fff",
+        "name": {
+            "en": "Line Q2",
+            "zh-Hans": "磁悬浮Q2号线"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wuhan on behalf of JKsn916.
This should fix #648

> @railmapgen/rmg-palette-resources@0.8.14 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#3D84C6`, fg=`#fff`
Line 2: bg=`#EB7CAF`, fg=`#fff`
Line 3: bg=`#D9B966`, fg=`#fff`
Line 4: bg=`#00ff00`, fg=`#000`
Line 5: bg=`#a62c00`, fg=`#fff`
Line 6: bg=`#008536`, fg=`#fff`
Line 7: bg=`#EB7900`, fg=`#fff`
Line 8: bg=`#a8ffff`, fg=`#000`
Line 9: bg=`#A5D4AD`, fg=`#fff`
Line 10: bg=`#8C3626`, fg=`#fff`
Line 11: bg=`#F2CF01`, fg=`#000`
Line 12: bg=`#00ffff`, fg=`#000`
Line 13: bg=`#25CAD0`, fg=`#fff`
Line 14: bg=`#7D55A3`, fg=`#fff`
Line 16: bg=`#CC0256`, fg=`#fff`
Line 21: bg=`#CF0192`, fg=`#fff`
Line 19: bg=`#00ffb3`, fg=`#000`
Line 17: bg=`#ffb0b0`, fg=`#000`
Line 43: bg=`#0000ff`, fg=`#fff`
Line 47: bg=`#ff0000`, fg=`#fff`
Line Q2: bg=`#388fc9`, fg=`#fff`