### PR TITLE
Resources: New palettes of Moscow

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -772,6 +772,17 @@
         }
     },
     {
+        "id": "moscow",
+        "country": "RU",
+        "name": {
+            "en": "Moscow",
+            "zh-Hans": "莫斯科",
+            "zh-Hant": "莫斯科",
+            "ru": "Москва",
+            "fr": "Moscou"
+        }
+    },
+    {
         "id": "munich",
         "country": "DE",
         "name": {

--- a/public/resources/palettes/moscow.json
+++ b/public/resources/palettes/moscow.json
@@ -1,0 +1,167 @@
+[
+    {
+        "id": "mos1",
+        "colour": "#c32126",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號綫",
+            "ru": "Сокольническая"
+        }
+    },
+    {
+        "id": "mos2",
+        "colour": "#2f8737",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號綫",
+            "ru": "Замоскворецкая"
+        }
+    },
+    {
+        "id": "mos3",
+        "colour": "#0365a2",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號綫",
+            "ru": "Арбатско-Покровская"
+        }
+    },
+    {
+        "id": "mos4",
+        "colour": "#17c1f3",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 4",
+            "zh-Hans": "4号线",
+            "zh-Hant": "4號綫",
+            "ru": "Филёвская"
+        }
+    },
+    {
+        "id": "mos5",
+        "colour": "#7a271f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號綫",
+            "ru": "Кольцевая"
+        }
+    },
+    {
+        "id": "mos6",
+        "colour": "#f57f20",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號綫",
+            "ru": "Калужско-Рижская"
+        }
+    },
+    {
+        "id": "mos7",
+        "colour": "#8f267c",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 7",
+            "zh-Hans": "7号线",
+            "zh-Hant": "7號綫",
+            "ru": "Таганско-Краснопресненская"
+        }
+    },
+    {
+        "id": "mos8",
+        "colour": "#ffd82f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號綫",
+            "ru": "Калининская"
+        }
+    },
+    {
+        "id": "mos9",
+        "colour": "#bcbdc0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 9",
+            "zh-Hans": "9号线",
+            "zh-Hant": "9號綫",
+            "ru": "Серпуховско-Тимирязевская"
+        }
+    },
+    {
+        "id": "mos10",
+        "colour": "#8dc647",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 10",
+            "zh-Hans": "10号线",
+            "zh-Hant": "10號綫",
+            "ru": "Люблинско-Дмитровская"
+        }
+    },
+    {
+        "id": "mos11",
+        "colour": "#58c5c7",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 11",
+            "zh-Hans": "11号线",
+            "zh-Hant": "11號綫",
+            "ru": "Каховская"
+        }
+    },
+    {
+        "id": "mos12",
+        "colour": "#b8c7e6",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 12",
+            "zh-Hans": "12号线",
+            "zh-Hant": "12號綫",
+            "ru": "Бутовская"
+        }
+    },
+    {
+        "id": "mos13",
+        "colour": "#1773b2",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 13",
+            "zh-Hans": "13号线",
+            "zh-Hant": "13號綫",
+            "ru": "Московский монорельс"
+        }
+    },
+    {
+        "id": "mos14",
+        "colour": "#ad342c",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 14",
+            "zh-Hans": "14号线",
+            "zh-Hant": "14號綫",
+            "ru": "Московское Центральное Кольцо"
+        }
+    },
+    {
+        "id": "mos15",
+        "colour": "#d789b0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 15",
+            "zh-Hans": "15号线",
+            "zh-Hant": "15號綫",
+            "ru": "Некрасовская"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Moscow on behalf of polygon827.
This should fix #653

> @railmapgen/rmg-palette-resources@0.8.14 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#c32126`, fg=`#fff`
Line 2: bg=`#2f8737`, fg=`#fff`
Line 3: bg=`#0365a2`, fg=`#fff`
Line 4: bg=`#17c1f3`, fg=`#fff`
Line 5: bg=`#7a271f`, fg=`#fff`
Line 6: bg=`#f57f20`, fg=`#fff`
Line 7: bg=`#8f267c`, fg=`#fff`
Line 8: bg=`#ffd82f`, fg=`#fff`
Line 9: bg=`#bcbdc0`, fg=`#fff`
Line 10: bg=`#8dc647`, fg=`#fff`
Line 11: bg=`#58c5c7`, fg=`#fff`
Line 12: bg=`#b8c7e6`, fg=`#fff`
Line 13: bg=`#1773b2`, fg=`#fff`
Line 14: bg=`#ad342c`, fg=`#fff`
Line 15: bg=`#d789b0`, fg=`#fff`