### PR TITLE
Resources: New palettes of Laocai

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -638,6 +638,15 @@
         }
     },
     {
+        "id": "laocai",
+        "country": "DG",
+        "name": {
+            "en": "Laocai",
+            "zh-Hans": "老蔡",
+            "zh-Hant": "老蔡"
+        }
+    },
+    {
         "id": "lima",
         "country": "PE",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -109,6 +109,15 @@
         "language": "de"
     },
     {
+        "id": "DG",
+        "name": {
+            "en": "People's Republic of Daguilandory",
+            "zh-Hans": "打鬼人民共和国",
+            "zh-Hant": "打鬼人民共和國"
+        },
+        "language": "zh-Hans"
+    },
+    {
         "id": "DK",
         "name": {
             "en": "Denmark",

--- a/public/resources/palettes/laocai.json
+++ b/public/resources/palettes/laocai.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "trl",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Trial Line| Ludicium linea",
+            "zh-Hans": "试运行线",
+            "zh-Hant": "測試綫"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Laocai on behalf of franklanyi.
This should fix #659

> @railmapgen/rmg-palette-resources@0.8.14 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Trial Line| Ludicium linea: bg=`#ff0000`, fg=`#fff`