### PR TITLE
Resources: New palettes of Milan

### DIFF
--- a/public/resources/palettes/milan.json
+++ b/public/resources/palettes/milan.json
@@ -1,165 +1,211 @@
 [
     {
         "id": "mm1",
+        "colour": "#E01023",
+        "fg": "#fff",
         "name": {
             "en": "M1",
             "it": "M1",
             "zh-Hans": "地铁1号线",
             "zh-Hant": "地鐵1號線"
-        },
-        "colour": "#E01023"
+        }
     },
     {
         "id": "mm2",
+        "colour": "#5F9334",
+        "fg": "#fff",
         "name": {
             "en": "M2",
             "it": "M2",
             "zh-Hans": "地铁2号线",
             "zh-Hant": "地鐵2號線"
-        },
-        "colour": "#5F9334"
+        }
     },
     {
         "id": "mm3",
+        "colour": "#F3A800",
+        "fg": "#fff",
         "name": {
             "en": "M3",
             "it": "M3",
             "zh-Hans": "地铁3号线",
             "zh-Hant": "地鐵3號線"
-        },
-        "colour": "#F3A800"
+        }
     },
     {
         "id": "mm4",
+        "colour": "#003777",
+        "fg": "#fff",
         "name": {
             "en": "M4",
             "it": "M4",
             "zh-Hans": "地铁4号线",
             "zh-Hant": "地鐵4號線"
-        },
-        "colour": "#20406A"
+        }
     },
     {
         "id": "mm5",
+        "colour": "#A394C6",
+        "fg": "#fff",
         "name": {
             "en": "M5",
             "it": "M5",
             "zh-Hans": "地铁5号线",
             "zh-Hant": "地鐵5號線"
-        },
-        "colour": "#A394C6"
+        }
     },
     {
         "id": "ms1",
+        "colour": "#E43129",
+        "fg": "#fff",
         "name": {
             "en": "S1",
             "it": "S1",
             "zh-Hans": "市域S1",
             "zh-Hant": "市域S1"
-        },
-        "colour": "#E43129"
+        }
     },
     {
         "id": "ms2",
+        "colour": "#009775",
+        "fg": "#fff",
         "name": {
             "en": "S2",
             "it": "S2",
             "zh-Hans": "市域S2",
             "zh-Hant": "市域S2"
-        },
-        "colour": "#009775"
+        }
     },
     {
         "id": "ms3",
+        "colour": "#AD2237",
+        "fg": "#fff",
         "name": {
             "en": "S3",
             "it": "S3",
             "zh-Hans": "市域S3",
             "zh-Hant": "市域S3"
-        },
-        "colour": "#AD2237"
+        }
     },
     {
         "id": "ms4",
+        "colour": "#7FB829",
+        "fg": "#000",
         "name": {
             "en": "S4",
             "it": "S4",
             "zh-Hans": "市域S4",
             "zh-Hant": "市域S4"
-        },
-        "colour": "#7FB829",
-        "fg": "#000"
+        }
     },
     {
         "id": "ms5",
+        "colour": "#F0922B",
+        "fg": "#000",
         "name": {
             "en": "S5",
             "it": "S5",
             "zh-Hans": "市域S5",
             "zh-Hant": "市域S5"
-        },
-        "colour": "#F0922B",
-        "fg": "#000"
+        }
     },
     {
         "id": "ms6",
+        "colour": "#F4CE0E",
+        "fg": "#000",
         "name": {
             "en": "S6",
             "it": "S6",
             "zh-Hans": "市域S6",
             "zh-Hant": "市域S6"
-        },
-        "colour": "#F4CE0E",
-        "fg": "#000"
+        }
     },
     {
         "id": "ms7",
+        "colour": "#E3296F",
+        "fg": "#fff",
         "name": {
             "en": "S7",
             "it": "S7",
             "zh-Hans": "市域S7",
             "zh-Hant": "市域S7"
-        },
-        "colour": "#E3296F"
+        }
     },
     {
         "id": "ms8",
+        "colour": "#F4B4B6",
+        "fg": "#fff",
         "name": {
             "en": "S8",
             "it": "S8",
             "zh-Hans": "市域S8",
             "zh-Hant": "市域S8"
-        },
-        "colour": "#F4B4B6"
+        }
     },
     {
         "id": "ms9",
+        "colour": "#A83B8E",
+        "fg": "#fff",
         "name": {
             "en": "S9",
             "it": "S9",
             "zh-Hans": "市域S9",
             "zh-Hant": "市域S9"
-        },
-        "colour": "#A83B8E"
+        }
+    },
+    {
+        "id": "ms10",
+        "colour": "#006699",
+        "fg": "#fff",
+        "name": {
+            "en": "S10",
+            "it": "S10",
+            "zh-Hans": "市域S10",
+            "zh-Hant": "市域S10"
+        }
     },
     {
         "id": "ms11",
+        "colour": "#9bafd9",
+        "fg": "#fff",
         "name": {
             "en": "S11",
             "it": "S11",
             "zh-Hans": "市域S11",
             "zh-Hant": "市域S11"
-        },
-        "colour": "#9BAFD9"
+        }
+    },
+    {
+        "id": "ms12",
+        "colour": "#223434",
+        "fg": "#fff",
+        "name": {
+            "en": "S12",
+            "it": "S12",
+            "zh-Hans": "市域S12",
+            "zh-Hant": "市域S12"
+        }
     },
     {
         "id": "ms13",
+        "colour": "#8E5536",
+        "fg": "#fff",
         "name": {
             "en": "S13",
             "it": "S13",
             "zh-Hans": "市域S13",
             "zh-Hant": "市域S13"
-        },
-        "colour": "#8E5536"
+        }
+    },
+    {
+        "id": "ms14",
+        "colour": "#9abc68",
+        "fg": "#fff",
+        "name": {
+            "en": "S14",
+            "it": "S14",
+            "zh-Hans": "市域S14",
+            "zh-Hant": "市域S14"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Milan on behalf of linchen1965.
This should fix #661

> @railmapgen/rmg-palette-resources@0.8.15 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

M1: bg=`#E01023`, fg=`#fff`
M2: bg=`#5F9334`, fg=`#fff`
M3: bg=`#F3A800`, fg=`#fff`
M4: bg=`#003777`, fg=`#fff`
M5: bg=`#A394C6`, fg=`#fff`
S1: bg=`#E43129`, fg=`#fff`
S2: bg=`#009775`, fg=`#fff`
S3: bg=`#AD2237`, fg=`#fff`
S4: bg=`#7FB829`, fg=`#000`
S5: bg=`#F0922B`, fg=`#000`
S6: bg=`#F4CE0E`, fg=`#000`
S7: bg=`#E3296F`, fg=`#fff`
S8: bg=`#F4B4B6`, fg=`#fff`
S9: bg=`#A83B8E`, fg=`#fff`
S10: bg=`#006699`, fg=`#fff`
S11: bg=`#9bafd9`, fg=`#fff`
S12: bg=`#223434`, fg=`#fff`
S13: bg=`#8E5536`, fg=`#fff`
S14: bg=`#9abc68`, fg=`#fff`