### PR TITLE
Resources: New palettes of Munich

### DIFF
--- a/public/resources/palettes/munich.json
+++ b/public/resources/palettes/munich.json
@@ -66,6 +66,17 @@
         }
     },
     {
+        "id": "mu7",
+        "colour": "#cec28b",
+        "fg": "#fff",
+        "name": {
+            "en": "U7",
+            "de": "U7",
+            "zh-Hans": "7号线",
+            "zh-Hant": "7號線"
+        }
+    },
+    {
         "id": "mu9",
         "colour": "#009fe3",
         "fg": "#fff",
@@ -121,6 +132,17 @@
         }
     },
     {
+        "id": "ms5",
+        "colour": "#ffcc00",
+        "fg": "#000",
+        "name": {
+            "en": "S5",
+            "de": "S5",
+            "zh-Hans": "市域S5",
+            "zh-Hant": "市域S5"
+        }
+    },
+    {
         "id": "ms6",
         "colour": "#00975f",
         "fg": "#fff",
@@ -154,6 +176,17 @@
         }
     },
     {
+        "id": "ms10",
+        "colour": "#993333",
+        "fg": "#fff",
+        "name": {
+            "en": "S10",
+            "de": "S10",
+            "zh-Hans": "市域S10",
+            "zh-Hant": "市域S10"
+        }
+    },
+    {
         "id": "ms20",
         "colour": "#F05972",
         "fg": "#fff",
@@ -162,6 +195,17 @@
             "de": "S20",
             "zh-Hans": "市域S20（跨线运行）",
             "zh-Hant": "市域S20（跨線運行）"
+        }
+    },
+    {
+        "id": "ms27",
+        "colour": "#f4929c",
+        "fg": "#fff",
+        "name": {
+            "en": "S27",
+            "de": "S27",
+            "zh-Hans": "市域S27",
+            "zh-Hant": "市域S27"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Munich on behalf of linchen1965.
This should fix #663

> @railmapgen/rmg-palette-resources@0.8.16 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

U1: bg=`#438136`, fg=`#fff`
U2: bg=`#C40C37`, fg=`#fff`
U3: bg=`#F36E31`, fg=`#fff`
U4: bg=`#0AB38D`, fg=`#fff`
U5: bg=`#B8740E`, fg=`#fff`
U6: bg=`#006CB3`, fg=`#fff`
U7: bg=`#cec28b`, fg=`#fff`
U9: bg=`#009fe3`, fg=`#fff`
S1: bg=`#15BFE9`, fg=`#fff`
S2: bg=`#71BF44`, fg=`#fff`
S3: bg=`#90268F`, fg=`#fff`
S4: bg=`#EE1C28`, fg=`#fff`
S5: bg=`#ffcc00`, fg=`#000`
S6: bg=`#00975f`, fg=`#fff`
S7: bg=`#88322C`, fg=`#fff`
S8: bg=`#EFA83C`, fg=`#fff`
S10: bg=`#993333`, fg=`#fff`
S20: bg=`#F05972`, fg=`#fff`
S27: bg=`#f4929c`, fg=`#fff`
Regional Train: bg=`#313D85`, fg=`#fff`