### PR TITLE
Resources: New palettes of Jinhua

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -561,6 +561,15 @@
         }
     },
     {
+        "id": "jinhua",
+        "country": "CN",
+        "name": {
+            "zh-Hans": "金华",
+            "zh-Hant": "金華",
+            "en": "Jinhua"
+        }
+    },
+    {
         "id": "kansai",
         "country": "JP",
         "name": {

--- a/public/resources/palettes/jinhua.json
+++ b/public/resources/palettes/jinhua.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "jyd",
+        "colour": "#e53333",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "金义东线",
+            "zh-Hant": "金義東線",
+            "en": "Jinyidong Line"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Jinhua on behalf of HangzhouMetro09024.
This should fix #673

> @railmapgen/rmg-palette-resources@0.8.17 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Jinyidong Line: bg=`#e53333`, fg=`#fff`