### PR TITLE
Resources: New palettes of Chuzhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -251,6 +251,15 @@
         }
     },
     {
+        "id": "chuzhou",
+        "country": "CN",
+        "name": {
+            "en": "Chuzhou",
+            "zh-Hans": "滁州",
+            "zh-Hant": "滁州"
+        }
+    },
+    {
         "id": "cochabamba",
         "country": "BO",
         "name": {

--- a/public/resources/palettes/chuzhou.json
+++ b/public/resources/palettes/chuzhou.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "ningchu",
+        "colour": "#ff631b",
+        "fg": "#fff",
+        "name": {
+            "en": "Nanjing-Chuzhou Line",
+            "zh-Hans": "宁滁线",
+            "zh-Hant": "寧滁線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Chuzhou on behalf of wongchito.
This should fix #680

> @railmapgen/rmg-palette-resources@0.8.17 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Nanjing-Chuzhou Line: bg=`#ff631b`, fg=`#fff`