### PR TITLE
Resources: New palettes of Osaka

### DIFF
--- a/public/resources/palettes/osaka.json
+++ b/public/resources/palettes/osaka.json
@@ -1,110 +1,119 @@
 [
     {
         "id": "m",
+        "colour": "#df2f27",
+        "fg": "#fff",
         "name": {
             "en": "Midosuji Line (M)",
             "ja": "御堂筋線",
             "zh-Hans": "御堂筋线",
             "zh-Hant": "御堂筋線"
-        },
-        "colour": "#D94E41"
+        }
     },
     {
         "id": "t",
+        "colour": "#a72f92",
+        "fg": "#fff",
         "name": {
             "en": "Tanimachi Line (T)",
             "ja": "谷町線",
             "zh-Hans": "谷町线",
             "zh-Hant": "谷町線"
-        },
-        "colour": "#AD37B2"
+        }
     },
     {
         "id": "y",
+        "colour": "#007bc2",
+        "fg": "#fff",
         "name": {
             "en": "Yotsubashi Line (Y)",
             "ja": "四つ橋線",
             "zh-Hans": "四桥线",
             "zh-Hant": "四橋線"
-        },
-        "colour": "#387DCE"
+        }
     },
     {
         "id": "c",
+        "colour": "#1ab04b",
+        "fg": "#fff",
         "name": {
             "en": "Chuo Line (C)",
             "ja": "中央線",
             "zh-Hans": "中央线",
             "zh-Hant": "中央線"
-        },
-        "colour": "#00AC5A"
+        }
     },
     {
         "id": "s",
+        "colour": "#f178ae",
+        "fg": "#fff",
         "name": {
             "en": "Sennichimae Line (S)",
             "ja": "千日前線",
             "zh-Hans": "千日前线",
             "zh-Hant": "千日前線"
-        },
-        "colour": "#F16FA8"
+        }
     },
     {
         "id": "k",
+        "colour": "#b14a30",
+        "fg": "#fff",
         "name": {
             "en": "Sakaisuji Line (K)",
             "ja": "堺筋線",
             "zh-Hans": "堺筋线",
             "zh-Hant": "堺筋線"
-        },
-        "colour": "#A25F41"
+        }
     },
     {
         "id": "n",
+        "colour": "#b8d432",
+        "fg": "#000",
         "name": {
             "en": "Nagahori Tsurumi-ryokuchi Line (N)",
             "ja": "長堀鶴見緑地線",
             "zh-Hans": "长堀鹤见绿地线",
             "zh-Hant": "長堀鶴見綠地線"
-        },
-        "colour": "#B4D93F",
-        "fg": "#000"
+        }
     },
     {
         "id": "i",
+        "colour": "#f89a1c",
+        "fg": "#000",
         "name": {
             "en": "Imazatosuji Line (I)",
             "ja": "今里筋線",
             "zh-Hans": "今里筋线",
             "zh-Hant": "今里筋線"
-        },
-        "colour": "#FF972D",
-        "fg": "#000"
+        }
     },
     {
         "id": "p",
+        "colour": "#00b2e6",
+        "fg": "#fff",
         "name": {
             "en": "New Tram (P)",
             "ja": "ニュートラム",
             "zh-Hans": "新电车",
             "zh-Hant": "新電車"
-        },
-        "colour": "#00B2DB"
+        }
     },
     {
         "id": "brt1",
+        "colour": "#F39800",
+        "fg": "#fff",
         "name": {
             "en": "BRT 1",
             "ja": "長居ルート（BRT 1）"
-        },
-        "colour": "#F39800"
+        }
     },
     {
         "id": "brt2",
+        "colour": "#EA5514",
+        "fg": "#fff",
         "name": {
             "en": "BRT 2",
             "ja": "あべの橋ルート（BRT 2）"
-        },
-        "colour": "#EA5514"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Osaka on behalf of aaronyz2007.
This should fix #683

> @railmapgen/rmg-palette-resources@0.8.18 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Midosuji Line (M): bg=`#df2f27`, fg=`#fff`
Tanimachi Line (T): bg=`#a72f92`, fg=`#fff`
Yotsubashi Line (Y): bg=`#007bc2`, fg=`#fff`
Chuo Line (C): bg=`#1ab04b`, fg=`#fff`
Sennichimae Line (S): bg=`#f178ae`, fg=`#fff`
Sakaisuji Line (K): bg=`#b14a30`, fg=`#fff`
Nagahori Tsurumi-ryokuchi Line (N): bg=`#b8d432`, fg=`#000`
Imazatosuji Line (I): bg=`#f89a1c`, fg=`#000`
New Tram (P): bg=`#00b2e6`, fg=`#fff`
BRT 1: bg=`#F39800`, fg=`#fff`
BRT 2: bg=`#EA5514`, fg=`#fff`