### PR TITLE
Resources: New palettes of Kansai Area

### DIFF
--- a/public/resources/palettes/kansai.json
+++ b/public/resources/palettes/kansai.json
@@ -1,216 +1,244 @@
 [
     {
         "id": "a",
+        "colour": "#007ac2",
+        "fg": "#fff",
         "name": {
             "en": "Hokuriku Line/Biwako Line/JR Kyōto Line/JR Kōbe Line (Tōkaidō Line)/San-yō Line/Akō Line (A)",
             "ja": "北陸線・琵琶湖線・ＪＲ京都線・ＪＲ神戸線（東海道線）・・山陽線・赤穂線",
             "zh-Hans": "北陆线/琵琶湖线/JR京都线/JR神户线/山阳线/赤穗线",
             "zh-Hant": "北陸線/琵琶湖線/JR京都線/JR神戶線/山陽線/赤穗線"
-        },
-        "colour": "#0070ad"
+        }
     },
     {
         "id": "b",
+        "colour": "#00b2e6",
+        "fg": "#fff",
         "name": {
             "en": "Kosei Line (B)",
             "ja": "湖西線",
             "zh-Hans": "湖西线",
             "zh-Hant": "湖西線"
-        },
-        "colour": "#00a9d2"
+        }
     },
     {
         "id": "c",
+        "colour": "#65b04c",
+        "fg": "#fff",
         "name": {
             "en": "Kusatsu Line (C)",
             "ja": "草津線",
             "zh-Hans": "草津线",
             "zh-Hant": "草津線"
-        },
-        "colour": "#61a74c"
+        }
     },
     {
         "id": "d",
+        "colour": "#ba7c31",
+        "fg": "#fff",
         "name": {
             "en": "Nara Line (D)",
             "ja": "奈良線",
             "zh-Hans": "奈良线",
             "zh-Hant": "奈良線"
-        },
-        "colour": "#ac7434"
+        }
     },
     {
         "id": "e",
+        "colour": "#7585c1",
+        "fg": "#fff",
         "name": {
             "en": "Sagano Line/San-in Line (E)",
             "ja": "嵯峨野線・山陰線",
             "zh-Hans": "嵯峨野线/山阴线",
             "zh-Hant": "嵯峨野線/山陰線"
-        },
-        "colour": "#707daf"
+        }
     },
     {
         "id": "f",
+        "colour": "#447694",
+        "fg": "#fff",
         "name": {
             "en": "Ōsaka Higashi Line (F)",
             "ja": "おおさか東線",
             "zh-Hans": "大阪东线",
             "zh-Hant": "大阪東線"
-        },
-        "colour": "#456d84"
+        }
     },
     {
         "id": "g",
+        "colour": "#fec210",
+        "fg": "#000",
         "name": {
             "en": "JR Takarazuka Line/Fukuchiyama Line (G)",
             "ja": "ＪＲ宝塚線・福知山線",
             "zh-Hans": "JR宝冢线/福知山线",
             "zh-Hant": "JR寶塚線/福知山線"
-        },
-        "colour": "#f6bd26",
-        "fg": "#000"
+        }
     },
     {
         "id": "h",
+        "colour": "#ee3689",
+        "fg": "#fff",
         "name": {
             "en": "JR Tōzai Line/Gakkentoshi Line (Katamachi Line) (H)",
             "ja": "ＪＲ東西線・学研都市線（片町線）",
             "zh-Hans": "JR东西线/学研都市线",
             "zh-Hant": "JR東西線/學研都市線"
-        },
-        "colour": "#dd397c"
+        }
     },
     {
         "id": "i",
+        "colour": "#03b08e",
+        "fg": "#fff",
         "name": {
             "en": "Kakogawa Line (I)",
             "ja": "加古川線",
             "zh-Hans": "加古川线",
             "zh-Hant": "加古川線"
-        },
-        "colour": "#00a480"
+        }
     },
     {
         "id": "j",
+        "colour": "#af2756",
+        "fg": "#fff",
         "name": {
             "en": "Bantan Line (J)",
             "ja": "播但線",
             "zh-Hans": "播但线",
             "zh-Hant": "播但線"
-        },
-        "colour": "#9c294e"
+        }
     },
     {
         "id": "k",
+        "colour": "#ef4b2b",
+        "fg": "#fff",
         "name": {
             "en": "Kishin Line (K)",
             "ja": "姫新線",
             "zh-Hans": "姬新线",
             "zh-Hant": "姬新線"
-        },
-        "colour": "#dd4731"
+        }
     },
     {
         "id": "l",
+        "colour": "#f89c1c",
+        "fg": "#000",
         "name": {
             "en": "Maizuru Line (L)",
             "ja": "舞鶴線",
             "zh-Hans": "舞鹤线",
             "zh-Hant": "舞鶴線"
-        },
-        "colour": "#ec962c",
-        "fg": "#000"
+        }
     },
     {
         "id": "o",
+        "colour": "#ee354f",
+        "fg": "#fff",
         "name": {
             "en": "Ōsaka Loop Line (O)",
             "ja": "大阪環状線",
             "zh-Hans": "大阪环状线",
             "zh-Hant": "大阪環狀線"
-        },
-        "colour": "#db394A"
+        }
     },
     {
         "id": "p",
+        "colour": "#233f97",
+        "fg": "#fff",
         "name": {
             "en": "JR Yumesaki Line (Sakurajima Line) (P)",
             "ja": "ＪＲゆめ咲線（桜島線）",
             "zh-Hans": "JR梦咲线",
             "zh-Hant": "JR夢咲線"
-        },
-        "colour": "#24387e"
+        }
     },
     {
         "id": "q",
+        "colour": "#02ad73",
+        "fg": "#fff",
         "name": {
             "en": "Yamatoji Line (Q)",
             "ja": "大和路線",
             "zh-Hans": "大和路线",
             "zh-Hant": "大和路線"
-        },
-        "colour": "#00a26d"
+        }
     },
     {
         "id": "r",
+        "colour": "#f89c1c",
+        "fg": "#000",
         "name": {
             "en": "Hanwa Line (R)",
             "ja": "阪和線",
             "zh-Hans": "阪和线",
             "zh-Hant": "阪和線"
-        },
-        "colour": "#ec962c",
-        "fg": "#000"
+        }
     },
     {
         "id": "s",
+        "colour": "#007ac2",
+        "fg": "#fff",
         "name": {
             "en": "Kansai-airport Line (S)",
             "ja": "関西空港線",
             "zh-Hans": "关西机场线",
             "zh-Hant": "關西機場線"
-        },
-        "colour": "#0070ad"
+        }
     },
     {
         "id": "t",
+        "colour": "#f5a2ba",
+        "fg": "#000",
         "name": {
             "en": "Wakayama Line (T)",
             "ja": "和歌山線",
             "zh-Hans": "和歌山线",
             "zh-Hant": "和歌山線"
-        },
-        "colour": "#eb9bae",
-        "fg": "#000"
+        }
     },
     {
         "id": "u",
+        "colour": "#cf2232",
+        "fg": "#fff",
         "name": {
             "en": "Man-yō Mahoroba Line (Sakurai Line) (U)",
             "ja": "万葉まほろば線（桜井線）",
             "zh-Hans": "万叶MAHOROBA线",
             "zh-Hant": "萬葉MAHOROBA線"
-        },
-        "colour": "#bc2634"
+        }
     },
     {
         "id": "v",
+        "colour": "#4b3f85",
+        "fg": "#fff",
         "name": {
             "en": "Kansai Line (V)",
             "ja": "関西線",
             "zh-Hans": "关西线",
             "zh-Hant": "關西線"
-        },
-        "colour": "#4b3f85"
+        }
     },
     {
         "id": "w",
+        "colour": "#00b0c1",
+        "fg": "#fff",
         "name": {
             "en": "Kinokuni Line (Kisei Line) (W)",
             "ja": "きのくに線（紀勢線）",
             "zh-Hans": "纪国线",
             "zh-Hant": "紀國線"
-        },
-        "colour": "#00a6b0"
+        }
+    },
+    {
+        "id": "shinkansen",
+        "colour": "#233f97",
+        "fg": "#fff",
+        "name": {
+            "en": "Tōkaidō, San-yō Shinkansen",
+            "ja": "東海道・山陽新幹線",
+            "zh-Hans": "东海道 · 山阳新干线",
+            "zh-Hant": "東海道 · 山陽新幹"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Kansai Area on behalf of aaronyz2007.
This should fix #685

> @railmapgen/rmg-palette-resources@0.8.18 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Hokuriku Line/Biwako Line/JR Kyōto Line/JR Kōbe Line (Tōkaidō Line)/San-yō Line/Akō Line (A): bg=`#007ac2`, fg=`#fff`
Kosei Line (B): bg=`#00b2e6`, fg=`#fff`
Kusatsu Line (C): bg=`#65b04c`, fg=`#fff`
Nara Line (D): bg=`#ba7c31`, fg=`#fff`
Sagano Line/San-in Line (E): bg=`#7585c1`, fg=`#fff`
Ōsaka Higashi Line (F): bg=`#447694`, fg=`#fff`
JR Takarazuka Line/Fukuchiyama Line (G): bg=`#fec210`, fg=`#000`
JR Tōzai Line/Gakkentoshi Line (Katamachi Line) (H): bg=`#ee3689`, fg=`#fff`
Kakogawa Line (I): bg=`#03b08e`, fg=`#fff`
Bantan Line (J): bg=`#af2756`, fg=`#fff`
Kishin Line (K): bg=`#ef4b2b`, fg=`#fff`
Maizuru Line (L): bg=`#f89c1c`, fg=`#000`
Ōsaka Loop Line (O): bg=`#ee354f`, fg=`#fff`
JR Yumesaki Line (Sakurajima Line) (P): bg=`#233f97`, fg=`#fff`
Yamatoji Line (Q): bg=`#02ad73`, fg=`#fff`
Hanwa Line (R): bg=`#f89c1c`, fg=`#000`
Kansai-airport Line (S): bg=`#007ac2`, fg=`#fff`
Wakayama Line (T): bg=`#f5a2ba`, fg=`#000`
Man-yō Mahoroba Line (Sakurai Line) (U): bg=`#cf2232`, fg=`#fff`
Kansai Line (V): bg=`#4b3f85`, fg=`#fff`
Kinokuni Line (Kisei Line) (W): bg=`#00b0c1`, fg=`#fff`
Tōkaidō, San-yō Shinkansen: bg=`#233f97`, fg=`#fff`