### PR TITLE
Resources: New palettes of Changsha

### DIFF
--- a/public/resources/palettes/changsha.json
+++ b/public/resources/palettes/changsha.json
@@ -11,7 +11,7 @@
     },
     {
         "id": "cs2",
-        "colour": "#8DC8E8",
+        "colour": "#03b2ff",
         "fg": "#fff",
         "name": {
             "en": "Line 2",
@@ -31,7 +31,7 @@
     },
     {
         "id": "cs4",
-        "colour": "#A51890",
+        "colour": "#974298",
         "fg": "#fff",
         "name": {
             "en": "Line 4",
@@ -41,7 +41,7 @@
     },
     {
         "id": "cs5",
-        "colour": "#FFD100",
+        "colour": "#fef102",
         "fg": "#000",
         "name": {
             "en": "Line 5",
@@ -51,7 +51,7 @@
     },
     {
         "id": "cs6",
-        "colour": "#0077C8",
+        "colour": "#323ebc",
         "fg": "#fff",
         "name": {
             "en": "Line 6",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Changsha on behalf of shengxirui.
This should fix #687

> @railmapgen/rmg-palette-resources@0.8.18 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#DA291C`, fg=`#fff`
Line 2: bg=`#03b2ff`, fg=`#fff`
Line 3: bg=`#C0DF16`, fg=`#000`
Line 4: bg=`#974298`, fg=`#fff`
Line 5: bg=`#fef102`, fg=`#000`
Line 6: bg=`#323ebc`, fg=`#fff`
Line 7: bg=`#009739`, fg=`#fff`
Line 8: bg=`#D9027D`, fg=`#fff`
Line 9: bg=`#00BFB2`, fg=`#000`
Line 10: bg=`#81312F`, fg=`#fff`
Line 11: bg=`#DE7C00`, fg=`#fff`
Line 12: bg=`#9063CD`, fg=`#fff`
Maglev Express: bg=`#F891A5`, fg=`#fff`
Intercity Railway: bg=`#999999`, fg=`#fff`