### PR TITLE
Resources: New palettes of Suzhou

### DIFF
--- a/public/resources/palettes/suzhou.json
+++ b/public/resources/palettes/suzhou.json
@@ -98,5 +98,25 @@
             "zh-Hans": "11号线",
             "zh-Hant": "11號線"
         }
+    },
+    {
+        "id": "tram",
+        "colour": "#d8e4c0",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram",
+            "zh-Hans": "有轨电车",
+            "zh-Hant": "有軌電車"
+        }
+    },
+    {
+        "id": "wkt",
+        "colour": "#e0e0e0",
+        "fg": "#fff",
+        "name": {
+            "en": "Lines under construction",
+            "zh-Hans": "未开通线路",
+            "zh-Hant": "未开通線路"
+        }
     }
 ]

--- a/public/resources/palettes/suzhou.json
+++ b/public/resources/palettes/suzhou.json
@@ -111,7 +111,7 @@
     },
     {
         "id": "wkt",
-        "colour": "#e0e0e0",
+        "colour": "#dddddd",
         "fg": "#fff",
         "name": {
             "en": "Lines under construction",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Suzhou on behalf of aaronyz2007.
This should fix #690

> @railmapgen/rmg-palette-resources@0.8.22 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#78BA25`, fg=`#fff`
Line 2: bg=`#ED3240`, fg=`#fff`
Line 3: bg=`#F88211`, fg=`#fff`
Line 4: bg=`#196EAE`, fg=`#fff`
Line 5: bg=`#E63A9A`, fg=`#fff`
Line 6: bg=`#41b6e6`, fg=`#fff`
Line 7: bg=`#a77bca`, fg=`#fff`
Line 8: bg=`#a09200`, fg=`#fff`
Line 10: bg=`#ca9a8e`, fg=`#fff`
Line 11: bg=`#f1c6a6`, fg=`#fff`
Tram: bg=`#d8e4c0`, fg=`#fff`
Lines under construction: bg=`#e0e0e0`, fg=`#fff`