### PR TITLE
Resources: New palettes of St. Louis

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1232,6 +1232,15 @@
         }
     },
     {
+        "id": "stlouis",
+        "country": "US",
+        "name": {
+            "en": "St. Louis",
+            "zh-Hans": "圣路易斯",
+            "zh-Hant": "聖路易斯"
+        }
+    },
+    {
         "id": "stockholm",
         "country": "SE",
         "name": {

--- a/public/resources/palettes/stlouis.json
+++ b/public/resources/palettes/stlouis.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "rl",
+        "colour": "#e93f33",
+        "fg": "#fff",
+        "name": {
+            "en": "Red Line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線"
+        }
+    },
+    {
+        "id": "bl",
+        "colour": "#001f61",
+        "fg": "#fff",
+        "name": {
+            "en": "Blue Line",
+            "zh-Hans": "蓝线",
+            "zh-Hant": "藍線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of St. Louis on behalf of DQB061204.
This should fix #694

> @railmapgen/rmg-palette-resources@0.8.22 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Red Line: bg=`#e93f33`, fg=`#fff`
Blue Line: bg=`#001f61`, fg=`#fff`