### PR TITLE
Resources: New palettes of Little Rock City

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -687,6 +687,15 @@
         }
     },
     {
+        "id": "littlerockcity",
+        "country": "US",
+        "name": {
+            "en": "Little Rock City",
+            "zh-Hans": "小石城",
+            "zh-Hant": "小石城"
+        }
+    },
+    {
         "id": "london",
         "country": "GBENG",
         "name": {

--- a/public/resources/palettes/littlerockcity.json
+++ b/public/resources/palettes/littlerockcity.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "scbl",
+        "colour": "#2e83c5",
+        "fg": "#fff",
+        "name": {
+            "en": "Streetcar Blue Line",
+            "zh-Hans": "有轨电车蓝线",
+            "zh-Hant": "有軌電車藍線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Little Rock City on behalf of DQB061204.
This should fix #696

> @railmapgen/rmg-palette-resources@0.8.22 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Streetcar Blue Line: bg=`#2e83c5`, fg=`#fff`