### PR TITLE
Resources: New palettes of Salt Lake City

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1102,6 +1102,15 @@
         }
     },
     {
+        "id": "saltlakecity",
+        "country": "US",
+        "name": {
+            "en": "Salt Lake City",
+            "zh-Hans": "盐湖城",
+            "zh-Hant": "鹽湖城"
+        }
+    },
+    {
         "id": "samara",
         "country": "RU",
         "name": {

--- a/public/resources/palettes/saltlakecity.json
+++ b/public/resources/palettes/saltlakecity.json
@@ -1,0 +1,62 @@
+[
+    {
+        "id": "el",
+        "colour": "#de3b30",
+        "fg": "#fff",
+        "name": {
+            "en": "Red Line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線"
+        }
+    },
+    {
+        "id": "gl",
+        "colour": "#74b735",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線"
+        }
+    },
+    {
+        "id": "bl",
+        "colour": "#14518b",
+        "fg": "#fff",
+        "name": {
+            "en": "Blue Line",
+            "zh-Hans": "蓝线",
+            "zh-Hant": "藍線"
+        }
+    },
+    {
+        "id": "sl",
+        "colour": "#8d8f90",
+        "fg": "#fff",
+        "name": {
+            "en": "S-Line",
+            "zh-Hans": "S线",
+            "zh-Hant": "S線"
+        }
+    },
+    {
+        "id": "fr",
+        "colour": "#9c4392",
+        "fg": "#fff",
+        "name": {
+            "en": "FrontRunner",
+            "zh-Hans": "领跑者号",
+            "zh-Hant": "領跑者號"
+        }
+    },
+    {
+        "id": "uvxbrt",
+        "colour": "#2c7dbb",
+        "fg": "#fff",
+        "name": {
+            "en": "UVX (BRT)",
+            "zh-Hans": "大学城线（BRT）",
+            "zh-Hant": "大學城線（BRT）"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Salt Lake City on behalf of DQB061204.
This should fix #698

> @railmapgen/rmg-palette-resources@0.8.22 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Red Line: bg=`#de3b30`, fg=`#fff`
Green Line: bg=`#74b735`, fg=`#fff`
Blue Line: bg=`#14518b`, fg=`#fff`
S-Line: bg=`#8d8f90`, fg=`#fff`
FrontRunner: bg=`#9c4392`, fg=`#fff`
UVX (BRT): bg=`#2c7dbb`, fg=`#fff`