### PR TITLE
Resources: New palettes of Liège

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -667,6 +667,16 @@
         }
     },
     {
+        "id": "liege",
+        "country": "BE",
+        "name": {
+            "en": "Liège",
+            "zh-Hans": "列日",
+            "zh-Hant": "列日",
+            "fr": "Liège"
+        }
+    },
+    {
         "id": "lima",
         "country": "PE",
         "name": {

--- a/public/resources/palettes/liege.json
+++ b/public/resources/palettes/liege.json
@@ -1,0 +1,46 @@
+[
+    {
+        "id": "ls41",
+        "colour": "#006435",
+        "fg": "#fff",
+        "name": {
+            "en": "S41",
+            "zh-Hans": "S41",
+            "zh-Hant": "S41",
+            "fr": "S41"
+        }
+    },
+    {
+        "id": "ls42",
+        "colour": "#ed5a07",
+        "fg": "#fff",
+        "name": {
+            "en": "S42",
+            "zh-Hans": "S42",
+            "zh-Hant": "S42",
+            "fr": "S42"
+        }
+    },
+    {
+        "id": "ls43",
+        "colour": "#2b267c",
+        "fg": "#fff",
+        "name": {
+            "en": "S43",
+            "zh-Hans": "S43",
+            "zh-Hant": "S43",
+            "fr": "S43"
+        }
+    },
+    {
+        "id": "ls44",
+        "colour": "#c7291d",
+        "fg": "#fff",
+        "name": {
+            "en": "S44",
+            "zh-Hans": "S44",
+            "zh-Hant": "S44",
+            "fr": "S44"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Liège on behalf of linchen1965.
This should fix #700

> @railmapgen/rmg-palette-resources@0.8.23 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

S41: bg=`#006435`, fg=`#fff`
S42: bg=`#ed5a07`, fg=`#fff`
S43: bg=`#2b267c`, fg=`#fff`
S44: bg=`#c7291d`, fg=`#fff`