### PR TITLE
Resources: New palettes of Iași

### DIFF
--- a/public/resources/palettes/iashi.json
+++ b/public/resources/palettes/iashi.json
@@ -103,9 +103,10 @@
         "colour": "#a82682",
         "fg": "#fff",
         "name": {
-            "en": "Autobu",
+            "en": "Autobus",
             "ro": "Autobuz",
-            "zh-Hans": "公交"
+            "zh-Hans": "公交",
+            "zh-Hant": "公車"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Iași on behalf of DQB061204.
This should fix #702

> @railmapgen/rmg-palette-resources@0.8.24 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#e5097f`, fg=`#fff`
Line 3: bg=`#009846`, fg=`#fff`
Line 5: bg=`#ef7f1a`, fg=`#fff`
Line 6: bg=`#f5b2b6`, fg=`#000`
Line 7: bg=`#393185`, fg=`#fff`
Line 8: bg=`#dbe285`, fg=`#000`
Line 9: bg=`#5ca595`, fg=`#fff`
Line 11: bg=`#ea556f`, fg=`#000`
Line 13: bg=`#00a0e3`, fg=`#fff`
Autobus: bg=`#a82682`, fg=`#fff`