### PR TITLE
Resources: New palettes of Nanchang

### DIFF
--- a/public/resources/palettes/nanchang.json
+++ b/public/resources/palettes/nanchang.json
@@ -13,7 +13,7 @@
     {
         "id": "nc2",
         "colour": "#ffda01",
-        "fg": "#000",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "ko": "2호선",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanchang on behalf of Jax-axl099.
This should fix #707

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#e60039`, fg=`#fff`
Line 2: bg=`#ffda01`, fg=`#fff`
Line 3: bg=`#0079c3`, fg=`#fff`
Line 4: bg=`#00a560`, fg=`#fff`
Line 5: bg=`#f0831e`, fg=`#fff`