### PR TITLE
Resources: New palettes of Xiangtan

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1492,6 +1492,15 @@
         }
     },
     {
+        "id": "xiangtan",
+        "country": "CN",
+        "name": {
+            "en": "Xiangtan",
+            "zh-Hans": "湘潭",
+            "zh-Hant": "湘潭"
+        }
+    },
+    {
         "id": "xuzhou",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/xiangtan.json
+++ b/public/resources/palettes/xiangtan.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "xtxh",
+        "colour": "#feafc7",
+        "fg": "#fff",
+        "name": {
+            "en": "Changsha-Zhuzhou-Xiangtan Intercity Metro Xihuan Line",
+            "zh-Hans": "长株潭城际轨道交通西环线",
+            "zh-Hant": "長株潭城際軌道交通西環缐"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Xiangtan on behalf of XiaoZiMo1234.
This should fix #709

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Changsha-Zhuzhou-Xiangtan Intercity Metro Xihuan Line: bg=`#feafc7`, fg=`#fff`