### PR TITLE
Resources: New palettes of Nanyang

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -929,6 +929,15 @@
         }
     },
     {
+        "id": "nanyang",
+        "country": "CN",
+        "name": {
+            "en": "Nanyang",
+            "zh-Hans": "南阳",
+            "zh-Hant": "南陽"
+        }
+    },
+    {
         "id": "naples",
         "country": "IT",
         "name": {

--- a/public/resources/palettes/nanyang.json
+++ b/public/resources/palettes/nanyang.json
@@ -1,0 +1,62 @@
+[
+    {
+        "id": "nys1",
+        "colour": "#b7192e",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh-Hans": "S1线",
+            "zh-Hant": "S1線"
+        }
+    },
+    {
+        "id": "nys2",
+        "colour": "#1964d0",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S2",
+            "zh-Hans": "S2线",
+            "zh-Hant": "S2線"
+        }
+    },
+    {
+        "id": "nys3",
+        "colour": "#e9d425",
+        "fg": "#000",
+        "name": {
+            "en": "Line S3",
+            "zh-Hans": "S3线",
+            "zh-Hant": "S3線"
+        }
+    },
+    {
+        "id": "nyt1",
+        "colour": "#16c348",
+        "fg": "#000",
+        "name": {
+            "en": "Line T1",
+            "zh-Hans": "T1线",
+            "zh-Hant": "T1線"
+        }
+    },
+    {
+        "id": "nyt2",
+        "colour": "#331196",
+        "fg": "#fff",
+        "name": {
+            "en": "Line T2",
+            "zh-Hans": "T2线",
+            "zh-Hant": "T2線"
+        }
+    },
+    {
+        "id": "nyt3",
+        "colour": "#af4f05",
+        "fg": "#fff",
+        "name": {
+            "en": "Line T3",
+            "zh-Hans": "T3线",
+            "zh-Hant": "T3線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanyang on behalf of chengran1234.
This should fix #713

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line S1: bg=`#b7192e`, fg=`#fff`
Line S2: bg=`#1964d0`, fg=`#fff`
Line S3: bg=`#e9d425`, fg=`#000`
Line T1: bg=`#16c348`, fg=`#000`
Line T2: bg=`#331196`, fg=`#fff`
Line T3: bg=`#af4f05`, fg=`#fff`