### PR TITLE
Resources: New palettes of Wenzhou

### DIFF
--- a/public/resources/palettes/wenzhou.json
+++ b/public/resources/palettes/wenzhou.json
@@ -20,5 +20,15 @@
             "zh-Hans": "S2线",
             "zh-Hant": "S2線"
         }
+    },
+    {
+        "id": "wzs3",
+        "colour": "#ff7e26",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S3",
+            "zh-Hans": "S3线",
+            "zh-Hant": "S3綫"
+        }
     }
 ]

--- a/public/resources/palettes/wenzhou.json
+++ b/public/resources/palettes/wenzhou.json
@@ -27,8 +27,9 @@
         "fg": "#fff",
         "name": {
             "en": "Line S3",
+            "ko": "S3호선",
             "zh-Hans": "S3线",
-            "zh-Hant": "S3綫"
+            "zh-Hant": "S3線"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wenzhou on behalf of WangHaoRan2211.
This should fix #719

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line S1: bg=`#0061ae`, fg=`#fff`
Line S2: bg=`#e4002b`, fg=`#fff`
Line S3: bg=`#ff7e26`, fg=`#fff`