### PR TITLE
Resources: New palettes of Sapporo

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1193,7 +1193,7 @@
         "country": "JP",
         "name": {
             "en": "Sapporo",
-            "ja": "さっぽろ",
+            "ja": "札幌",
             "zh-Hans": "札幌",
             "zh-Hant": "札幌"
         }

--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1189,6 +1189,16 @@
         }
     },
     {
+        "id": "sapporo",
+        "country": "JP",
+        "name": {
+            "en": "Sapporo",
+            "ja": "さっぽろ",
+            "zh-Hans": "札幌",
+            "zh-Hant": "札幌"
+        }
+    },
+    {
         "id": "seoul",
         "country": "KR",
         "name": {

--- a/public/resources/palettes/sapporo.json
+++ b/public/resources/palettes/sapporo.json
@@ -1,0 +1,46 @@
+[
+    {
+        "id": "N",
+        "colour": "#088000",
+        "fg": "#fff",
+        "name": {
+            "en": "Nanboku Line",
+            "zh-Hans": "南北线",
+            "zh-Hant": "南北線",
+            "ja": " 南北線"
+        }
+    },
+    {
+        "id": "T",
+        "colour": "#ff9900",
+        "fg": "#fff",
+        "name": {
+            "en": "Tozai Line",
+            "zh-Hant": "東西線",
+            "ja": "東西線",
+            "zh-Hans": "东西线"
+        }
+    },
+    {
+        "id": "H",
+        "colour": "#0000ff",
+        "fg": "#fff",
+        "name": {
+            "en": "Toho Line",
+            "ja": "東豐線",
+            "zh-Hant": "東豐線",
+            "zh-Hans": "东丰线"
+        }
+    },
+    {
+        "id": "SC",
+        "colour": "#808080",
+        "fg": "#fff",
+        "name": {
+            "en": "Sapporo Street Car",
+            "zh-Hans": "札幌市电",
+            "zh-Hant": "札幌市電",
+            "ja": "札幌市電"
+        }
+    }
+]

--- a/public/resources/palettes/sapporo.json
+++ b/public/resources/palettes/sapporo.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "N",
-        "colour": "#088000",
+        "colour": "#088002",
         "fg": "#fff",
         "name": {
             "en": "Nanboku Line",
@@ -23,7 +23,7 @@
     },
     {
         "id": "H",
-        "colour": "#0000ff",
+        "colour": "#0166cc",
         "fg": "#fff",
         "name": {
             "en": "Toho Line",
@@ -34,7 +34,7 @@
     },
     {
         "id": "SC",
-        "colour": "#808080",
+        "colour": "#b2b2b2",
         "fg": "#fff",
         "name": {
             "en": "Sapporo Street Car",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Sapporo on behalf of SilconFinta.
This should fix #723

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Nanboku Line: bg=`#088000`, fg=`#fff`
Tozai Line: bg=`#ff9900`, fg=`#fff`
Toho Line: bg=`#0000ff`, fg=`#fff`
Sapporo Street Car: bg=`#808080`, fg=`#fff`