### PR TITLE
Resources: New palettes of Shaoxing

### DIFF
--- a/public/resources/palettes/shaoxing.json
+++ b/public/resources/palettes/shaoxing.json
@@ -6,7 +6,21 @@
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
-            "zh-Hant": "1號線"
+            "zh-Hant": "1號線",
+            "ja": "1号線",
+            "ko": "1호선"
+        }
+    },
+    {
+        "id": "sx2",
+        "colour": "#307fe2",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線",
+            "ko": "2호선",
+            "ja": "2号線"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shaoxing on behalf of 28yfang.
This should fix #725

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#c5003e`, fg=`#fff`
Line 2: bg=`#307fe2`, fg=`#fff`