### PR TITLE
Resources: New palettes of Sankt Peterburg

### DIFF
--- a/public/resources/palettes/sanktpeterburg.json
+++ b/public/resources/palettes/sanktpeterburg.json
@@ -1,52 +1,68 @@
 [
     {
         "id": "spg1",
+        "colour": "#D51D2E",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "ru": "Линия 1 ",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#D51D2E"
+        }
     },
     {
         "id": "spg2",
+        "colour": "#177ECE",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "ru": "Линия 2 ",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#177ECE"
+        }
     },
     {
         "id": "spg3",
+        "colour": "#1C9A53",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "ru": "Линия 3 ",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#1C9A53"
+        }
     },
     {
         "id": "spg4",
+        "colour": "#DE710A",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "ru": "Линия 4 ",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#DE710A"
+        }
     },
     {
         "id": "spg5",
+        "colour": "#6E0A76",
+        "fg": "#fff",
         "name": {
             "en": "Line 5",
             "ru": "Линия 5 ",
             "zh-Hans": "5号线",
             "zh-Hant": "5號線"
-        },
-        "colour": "#6E0A76"
+        }
+    },
+    {
+        "id": "spg6",
+        "colour": "#c2a68a",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號綫",
+            "ru": "Линия 6"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Sankt Peterburg on behalf of Jax-axl099.
This should fix #727

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#D51D2E`, fg=`#fff`
Line 2: bg=`#177ECE`, fg=`#fff`
Line 3: bg=`#1C9A53`, fg=`#fff`
Line 4: bg=`#DE710A`, fg=`#fff`
Line 5: bg=`#6E0A76`, fg=`#fff`
Line 6: bg=`#c2a68a`, fg=`#fff`
Printing all colours...

Line 1: bg=`#D51D2E`, fg=`#fff`
Line 2: bg=`#177ECE`, fg=`#fff`
Line 3: bg=`#1C9A53`, fg=`#fff`
Line 4: bg=`#DE710A`, fg=`#fff`
Line 5: bg=`#6E0A76`, fg=`#fff`
Line 6: bg=`#c2a68a`, fg=`#fff`