### PR TITLE
Resources: New palettes of Zhuhai

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1537,5 +1537,14 @@
             "zh-Hans": "郑州",
             "zh-Hant": "鄭州"
         }
+    },
+    {
+        "id": "zhuhai",
+        "country": "CN",
+        "name": {
+            "en": "Zhuhai",
+            "zh-Hans": "珠海",
+            "zh-Hant": "珠海"
+        }
     }
 ]

--- a/public/resources/palettes/zhuhai.json
+++ b/public/resources/palettes/zhuhai.json
@@ -1,0 +1,72 @@
+[
+    {
+        "id": "zh1",
+        "colour": "#ed9c55",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "一号线",
+            "zh-Hant": "一號線"
+        }
+    },
+    {
+        "id": "zh2",
+        "colour": "#7f4080",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "二号线",
+            "zh-Hant": "二號線"
+        }
+    },
+    {
+        "id": "ztl1",
+        "colour": "#08ade9",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line 1",
+            "zh-Hans": "有轨电车一号线",
+            "zh-Hant": "有軌電車一號線"
+        }
+    },
+    {
+        "id": "ztl2",
+        "colour": "#04ab53",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line 2",
+            "zh-Hans": "有轨电车二号线",
+            "zh-Hant": "有軌電車二號線"
+        }
+    },
+    {
+        "id": "ZAIR",
+        "colour": "#348dc4",
+        "fg": "#fff",
+        "name": {
+            "en": "Zhuhai Airport Intercity Rail",
+            "zh-Hans": "珠机城际轨道",
+            "zh-Hant": "珠機城際軌道"
+        }
+    },
+    {
+        "id": "GZIR",
+        "colour": "#c71121",
+        "fg": "#fff",
+        "name": {
+            "en": "Guangzhou Zhuhai Intercity Rail Transit",
+            "zh-Hans": "广珠城际轨道",
+            "zh-Hant": "廣珠城際軌道"
+        }
+    },
+    {
+        "id": "MLRT",
+        "colour": "#3491c7",
+        "fg": "#fff",
+        "name": {
+            "en": "Macao LRT",
+            "zh-Hans": "澳门轻轨",
+            "zh-Hant": "澳門捷運"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Zhuhai on behalf of Aoeoy.
This should fix #730

> @railmapgen/rmg-palette-resources@0.8.27 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#ed9c55`, fg=`#fff`
Line 2: bg=`#7f4080`, fg=`#fff`
Tram Line 1: bg=`#08ade9`, fg=`#fff`
Tram Line 2: bg=`#04ab53`, fg=`#fff`
Zhuhai Airport Intercity Rail: bg=`#348dc4`, fg=`#fff`
Guangzhou Zhuhai Intercity Rail Transit: bg=`#c71121`, fg=`#fff`
Macao LRT: bg=`#3491c7`, fg=`#fff`