### PR TITLE
Resources: New palettes of Shanghai

### DIFF
--- a/public/resources/palettes/shanghai.json
+++ b/public/resources/palettes/shanghai.json
@@ -305,7 +305,8 @@
         "fg": "#fff",
         "name": {
             "zh-Hans": "金山铁路",
-            "en": "Jinshan Railway"
+            "en": "Jinshan Railway",
+            "zh-Hant": "金山鐵路"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shanghai on behalf of DQB061204.
This should fix #734

> @railmapgen/rmg-palette-resources@0.8.28 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#E3002B`, fg=`#fff`
Line 2: bg=`#8CC220`, fg=`#000`
Line 3: bg=`#FCD600`, fg=`#000`
Line 4: bg=`#461D84`, fg=`#fff`
Line 5: bg=`#944D9A`, fg=`#fff`
Line 6: bg=`#D40068`, fg=`#fff`
Line 7: bg=`#ED6F00`, fg=`#000`
Line 8: bg=`#0094D8`, fg=`#fff`
Line 9: bg=`#87CAED`, fg=`#000`
Line 10: bg=`#C6AFD4`, fg=`#000`
Line 11: bg=`#871C2B`, fg=`#fff`
Line 12: bg=`#007B61`, fg=`#fff`
Line 13: bg=`#E999C0`, fg=`#000`
Line 14: bg=`#626020`, fg=`#fff`
Line 15: bg=`#BCA886`, fg=`#000`
Line 16: bg=`#98D1C0`, fg=`#000`
Line 17: bg=`#BC796F`, fg=`#fff`
Line 18: bg=`#C4984F`, fg=`#000`
Line 19: bg=`#48864D`, fg=`#fff`
Line 20: bg=`#365299`, fg=`#fff`
Line 21: bg=`#D6C66C`, fg=`#000`
Line 23: bg=`#E0815E`, fg=`#fff`
Pujiang Line: bg=`#B5B5B6`, fg=`#fff`
Songjiang Tram T1: bg=`#FF0000`, fg=`#fff`
Songjiang Tram T2: bg=`#46837B`, fg=`#fff`
Songjiang Tram T3: bg=`#009400`, fg=`#fff`
Songjiang Tram T4: bg=`#FF00FF`, fg=`#fff`
Songjiang Tram T5: bg=`#00FD00`, fg=`#fff`
Songjiang Tram T6: bg=`#6E00DD`, fg=`#fff`
Shanghai Maglev Train: bg=`#009090`, fg=`#fff`
Jinshan Railway: bg=`#000000`, fg=`#fff`
Airport Link Line: bg=`#266883`, fg=`#fff`
Jiamin Line: bg=`#733C54`, fg=`#fff`
Chongming Line: bg=`#6BB392`, fg=`#000`