### PR TITLE
Resources: New palettes of Bordeaux

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -117,6 +117,16 @@
         }
     },
     {
+        "id": "bordeaux",
+        "country": "FR",
+        "name": {
+            "en": "Bordeaux",
+            "zh-Hans": "波尔多",
+            "zh-Hant": "波爾多",
+            "fr": "Bordeaux"
+        }
+    },
+    {
         "id": "boston",
         "country": "US",
         "name": {

--- a/public/resources/palettes/bordeaux.json
+++ b/public/resources/palettes/bordeaux.json
@@ -1,0 +1,420 @@
+[
+    {
+        "id": "ba",
+        "colour": "#831f82",
+        "fg": "#fff",
+        "name": {
+            "en": "Line A",
+            "zh-Hans": "A线",
+            "zh-Hant": "A缐",
+            "fr": "Ligne A"
+        }
+    },
+    {
+        "id": "bb",
+        "colour": "#e40040",
+        "fg": "#fff",
+        "name": {
+            "en": "Line B",
+            "zh-Hans": "B线",
+            "zh-Hant": "B缐",
+            "fr": "Ligne B"
+        }
+    },
+    {
+        "id": "bc",
+        "colour": "#d35097",
+        "fg": "#fff",
+        "name": {
+            "en": "Line C",
+            "zh-Hans": "C线",
+            "zh-Hant": "C缐",
+            "fr": "Ligne C"
+        }
+    },
+    {
+        "id": "bd",
+        "colour": "#9361a1",
+        "fg": "#fff",
+        "name": {
+            "en": "Line D",
+            "zh-Hans": "D线",
+            "zh-Hant": "D缐",
+            "fr": "Ligne D"
+        }
+    },
+    {
+        "id": "bl",
+        "colour": "#0087cc",
+        "fg": "#fff",
+        "name": {
+            "en": "Lianes",
+            "zh-Hans": "干线公交",
+            "zh-Hant": "幹線公交",
+            "fr": "Lianes"
+        }
+    },
+    {
+        "id": "bp",
+        "colour": "#ef7d00",
+        "fg": "#fff",
+        "name": {
+            "en": "Peripheral Lines",
+            "zh-Hans": "外围公交",
+            "zh-Hant": "外圍公交",
+            "fr": "Lignes Periphériques"
+        }
+    },
+    {
+        "id": "bi",
+        "colour": "#7c9a2e",
+        "fg": "#fff",
+        "name": {
+            "en": "Citeis",
+            "zh-Hans": "市际公交",
+            "zh-Hant": "市際公交",
+            "fr": "Citeis"
+        }
+    },
+    {
+        "id": "b3",
+        "colour": "#0bbbef",
+        "fg": "#fff",
+        "name": {
+            "en": "Bat3",
+            "zh-Hans": "Bat3",
+            "zh-Hant": "Bat3",
+            "fr": "Bat3"
+        }
+    },
+    {
+        "id": "btd",
+        "colour": "#c31632",
+        "fg": "#fff",
+        "name": {
+            "en": "D15/D31/D33/D44/D45/D51/D52",
+            "zh-Hans": "D15/D31/D33/D44/D45/D51/D52",
+            "zh-Hant": "D15/D31/D33/D44/D45/D51/D52",
+            "fr": "D15/D31/D33/D44/D45/D51/D52"
+        }
+    },
+    {
+        "id": "btl",
+        "colour": "#3e884c",
+        "fg": "#fff",
+        "name": {
+            "en": "L13/L15/L31/L32/L33/L42/L44/L45/L51/L52",
+            "zh-Hans": "L13/L15/L31/L32/L33/L42/L44/L45/L51/L52",
+            "zh-Hant": "L13/L15/L31/L32/L33/L42/L44/L45/L51/L52",
+            "fr": "L13/L15/L31/L32/L33/L42/L44/L45/L51/L52"
+        }
+    },
+    {
+        "id": "btf",
+        "colour": "#7468ac",
+        "fg": "#fff",
+        "name": {
+            "en": "F32/F41/F42/F43/F44",
+            "zh-Hans": "F32/F41/F42/F43/F44",
+            "zh-Hant": "F32/F41/F42/F43/F44",
+            "fr": "F32/F41/F42/F43/F44"
+        }
+    },
+    {
+        "id": "b201",
+        "colour": "#8e5928",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 201",
+            "zh-Hans": "区域巴士201",
+            "zh-Hant": "區域巴士201",
+            "fr": "Car régional 201"
+        }
+    },
+    {
+        "id": "b202",
+        "colour": "#6cca98",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 202",
+            "zh-Hans": "区域巴士202",
+            "zh-Hant": "區域巴士202",
+            "fr": "Car régional 202"
+        }
+    },
+    {
+        "id": "b301",
+        "colour": "#718472",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 301",
+            "zh-Hans": "区域巴士301",
+            "zh-Hant": "區域巴士301",
+            "fr": "Car régional 301"
+        }
+    },
+    {
+        "id": "b302",
+        "colour": "#a65a2a",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 302",
+            "zh-Hans": "区域巴士302",
+            "zh-Hant": "區域巴士302",
+            "fr": "Car régional 302"
+        }
+    },
+    {
+        "id": "b303",
+        "colour": "#daa900",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 303",
+            "zh-Hans": "区域巴士303",
+            "zh-Hant": "區域巴士303",
+            "fr": "Car régional 303"
+        }
+    },
+    {
+        "id": "b304",
+        "colour": "#e7344c",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 304",
+            "zh-Hans": "区域巴士304",
+            "zh-Hant": "區域巴士304",
+            "fr": "Car régional 304"
+        }
+    },
+    {
+        "id": "b401",
+        "colour": "#007934",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 401",
+            "zh-Hans": "区域巴士401",
+            "zh-Hant": "區域巴士401",
+            "fr": "Car régional 401"
+        }
+    },
+    {
+        "id": "b402",
+        "colour": "#5eb3e4",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 402",
+            "zh-Hans": "区域巴士402",
+            "zh-Hant": "區域巴士402",
+            "fr": "Car régional 402"
+        }
+    },
+    {
+        "id": "b403",
+        "colour": "#c5b000",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 403",
+            "zh-Hans": "区域巴士403",
+            "zh-Hant": "區域巴士403",
+            "fr": "Car régional 403"
+        }
+    },
+    {
+        "id": "b404",
+        "colour": "#b68400",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 404",
+            "zh-Hans": "区域巴士404",
+            "zh-Hant": "區域巴士404",
+            "fr": "Car régional 404"
+        }
+    },
+    {
+        "id": "b405",
+        "colour": "#946857",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 405",
+            "zh-Hans": "区域巴士405",
+            "zh-Hant": "區域巴士405",
+            "fr": "Car régional 405"
+        }
+    },
+    {
+        "id": "b406",
+        "colour": "#62b452",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 406",
+            "zh-Hans": "区域巴士406",
+            "zh-Hant": "區域巴士406",
+            "fr": "Car régional 406"
+        }
+    },
+    {
+        "id": "b407",
+        "colour": "#c31932",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 407",
+            "zh-Hans": "区域巴士407",
+            "zh-Hant": "區域巴士407",
+            "fr": "Car régional 407"
+        }
+    },
+    {
+        "id": "b501",
+        "colour": "#8cc9a6",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 501",
+            "zh-Hans": "区域巴士501",
+            "zh-Hant": "區域巴士501",
+            "fr": "Car régional 501"
+        }
+    },
+    {
+        "id": "b502",
+        "colour": "#ff251b",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 502",
+            "zh-Hans": "区域巴士502",
+            "zh-Hant": "區域巴士502",
+            "fr": "Car régional 502"
+        }
+    },
+    {
+        "id": "b503",
+        "colour": "#00754a",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 503",
+            "zh-Hans": "区域巴士503",
+            "zh-Hant": "區域巴士503",
+            "fr": "Car régional 503"
+        }
+    },
+    {
+        "id": "b504",
+        "colour": "#a09857",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 504",
+            "zh-Hans": "区域巴士504",
+            "zh-Hant": "區域巴士504",
+            "fr": "Car régional 504"
+        }
+    },
+    {
+        "id": "b505",
+        "colour": "#f18c02",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 505",
+            "zh-Hans": "区域巴士505",
+            "zh-Hant": "區域巴士505",
+            "fr": "Car régional 505"
+        }
+    },
+    {
+        "id": "b506",
+        "colour": "#1082c6",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 506",
+            "zh-Hans": "区域巴士506",
+            "zh-Hant": "區域巴士506",
+            "fr": "Car régional 506"
+        }
+    },
+    {
+        "id": "b601",
+        "colour": "#8d6e36",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 601",
+            "zh-Hans": "区域巴士601",
+            "zh-Hant": "區域巴士601",
+            "fr": "Car régional 601"
+        }
+    },
+    {
+        "id": "b602",
+        "colour": "#5b7e96",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 602",
+            "zh-Hans": "区域巴士602",
+            "zh-Hant": "區域巴士602",
+            "fr": "Car régional 602"
+        }
+    },
+    {
+        "id": "b701",
+        "colour": "#004d43",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 701",
+            "zh-Hans": "区域巴士701",
+            "zh-Hant": "區域巴士701",
+            "fr": "Car régional 701"
+        }
+    },
+    {
+        "id": "b702",
+        "colour": "#ce7013",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 702",
+            "zh-Hans": "区域巴士702",
+            "zh-Hant": "區域巴士702",
+            "fr": "Car régional 702"
+        }
+    },
+    {
+        "id": "b703",
+        "colour": "#c7b51e",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 703",
+            "zh-Hans": "区域巴士703",
+            "zh-Hant": "區域巴士703",
+            "fr": "Car régional 703"
+        }
+    },
+    {
+        "id": "b704",
+        "colour": "#0878be",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 704",
+            "zh-Hans": "区域巴士704",
+            "zh-Hant": "區域巴士704",
+            "fr": "Car régional 704"
+        }
+    },
+    {
+        "id": "b705",
+        "colour": "#863399",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 705",
+            "zh-Hans": "区域巴士705",
+            "zh-Hant": "區域巴士705",
+            "fr": "Car régional 705"
+        }
+    },
+    {
+        "id": "b710",
+        "colour": "#efb600",
+        "fg": "#fff",
+        "name": {
+            "en": "Regional bus 710",
+            "zh-Hans": "区域巴士710",
+            "zh-Hant": "區域巴士710",
+            "fr": "Car régional 710"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Bordeaux on behalf of linchen1965.
This should fix #743

> @railmapgen/rmg-palette-resources@0.8.30 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line A: bg=`#831f82`, fg=`#fff`
Line B: bg=`#e40040`, fg=`#fff`
Line C: bg=`#d35097`, fg=`#fff`
Line D: bg=`#9361a1`, fg=`#fff`
Lianes: bg=`#0087cc`, fg=`#fff`
Peripheral Lines: bg=`#ef7d00`, fg=`#fff`
Citeis: bg=`#7c9a2e`, fg=`#fff`
Bat3: bg=`#0bbbef`, fg=`#fff`
D15/D31/D33/D44/D45/D51/D52: bg=`#c31632`, fg=`#fff`
L13/L15/L31/L32/L33/L42/L44/L45/L51/L52: bg=`#3e884c`, fg=`#fff`
F32/F41/F42/F43/F44: bg=`#7468ac`, fg=`#fff`
Regional bus 201: bg=`#8e5928`, fg=`#fff`
Regional bus 202: bg=`#6cca98`, fg=`#fff`
Regional bus 301: bg=`#718472`, fg=`#fff`
Regional bus 302: bg=`#a65a2a`, fg=`#fff`
Regional bus 303: bg=`#daa900`, fg=`#fff`
Regional bus 304: bg=`#e7344c`, fg=`#fff`
Regional bus 401: bg=`#007934`, fg=`#fff`
Regional bus 402: bg=`#5eb3e4`, fg=`#fff`
Regional bus 403: bg=`#c5b000`, fg=`#fff`
Regional bus 404: bg=`#b68400`, fg=`#fff`
Regional bus 405: bg=`#946857`, fg=`#fff`
Regional bus 406: bg=`#62b452`, fg=`#fff`
Regional bus 407: bg=`#c31932`, fg=`#fff`
Regional bus 501: bg=`#8cc9a6`, fg=`#fff`
Regional bus 502: bg=`#ff251b`, fg=`#fff`
Regional bus 503: bg=`#00754a`, fg=`#fff`
Regional bus 504: bg=`#a09857`, fg=`#fff`
Regional bus 505: bg=`#f18c02`, fg=`#fff`
Regional bus 506: bg=`#1082c6`, fg=`#fff`
Regional bus 601: bg=`#8d6e36`, fg=`#fff`
Regional bus 602: bg=`#5b7e96`, fg=`#fff`
Regional bus 701: bg=`#004d43`, fg=`#fff`
Regional bus 702: bg=`#ce7013`, fg=`#fff`
Regional bus 703: bg=`#c7b51e`, fg=`#fff`
Regional bus 704: bg=`#0878be`, fg=`#fff`
Regional bus 705: bg=`#863399`, fg=`#fff`
Regional bus 710: bg=`#efb600`, fg=`#fff`