### PR TITLE
Resources: New palettes of Changsha

### DIFF
--- a/public/resources/palettes/changsha.json
+++ b/public/resources/palettes/changsha.json
@@ -138,5 +138,15 @@
             "zh-Hans": "城际铁路",
             "zh-Hant": "城際鐵路"
         }
+    },
+    {
+        "id": "csxl",
+        "colour": "#db7093",
+        "fg": "#fff",
+        "name": {
+            "en": "Xihuan line",
+            "zh-Hans": "西环线",
+            "zh-Hant": "西環線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Changsha on behalf of Windows-Taskmgr.
This should fix #752

> @railmapgen/rmg-palette-resources@0.8.32 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#DA291C`, fg=`#fff`
Line 2: bg=`#8DC8E8`, fg=`#fff`
Line 3: bg=`#C0DF16`, fg=`#000`
Line 4: bg=`#A51890`, fg=`#fff`
Line 5: bg=`#FFD100`, fg=`#000`
Line 6: bg=`#0077C8`, fg=`#fff`
Line 7: bg=`#009739`, fg=`#fff`
Line 8: bg=`#D9027D`, fg=`#fff`
Line 9: bg=`#00BFB2`, fg=`#000`
Line 10: bg=`#81312F`, fg=`#fff`
Line 11: bg=`#DE7C00`, fg=`#fff`
Line 12: bg=`#9063CD`, fg=`#fff`
Maglev Express: bg=`#F891A5`, fg=`#fff`
Intercity Railway: bg=`#999999`, fg=`#fff`
Xihuan line: bg=`#db7093`, fg=`#fff`