### PR TITLE
Resources: New palettes of Wuhu

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1485,6 +1485,15 @@
         }
     },
     {
+        "id": "wuhu",
+        "country": "CN",
+        "name": {
+            "en": "Wuhu",
+            "zh-Hans": "芜湖",
+            "zh-Hant": "蕪湖"
+        }
+    },
+    {
         "id": "wuxi",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/wuhu.json
+++ b/public/resources/palettes/wuhu.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "wuhu1",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線"
+        }
+    },
+    {
+        "id": "wuhu2",
+        "colour": "#007aff",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wuhu on behalf of Wuyirende.
This should fix #754

> @railmapgen/rmg-palette-resources@0.8.33 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#ff0000`, fg=`#fff`
Line 2: bg=`#007aff`, fg=`#fff`