### PR TITLE
Resources: New palettes of Manila

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -801,6 +801,15 @@
         }
     },
     {
+        "id": "manila",
+        "country": "PH",
+        "name": {
+            "en": "Manila",
+            "zh-Hans": "马尼拉",
+            "zh-Hant": "馬尼拉"
+        }
+    },
+    {
         "id": "marseille",
         "country": "FR",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -356,6 +356,15 @@
         "language": "es"
     },
     {
+        "id": "PH",
+        "name": {
+            "en": "Philippines",
+            "zh-Hans": "菲律宾",
+            "zh-Hant": "菲律賓"
+        },
+        "language": "en"
+    },
+    {
         "id": "PK",
         "name": {
             "en": "Pakistan",

--- a/public/resources/palettes/manila.json
+++ b/public/resources/palettes/manila.json
@@ -1,0 +1,32 @@
+[
+    {
+        "id": "lrt1",
+        "colour": "#01844b",
+        "fg": "#fff",
+        "name": {
+            "en": "LRT Line 1",
+            "zh-Hans": "LRT第1行",
+            "zh-Hant": "LRT第1行"
+        }
+    },
+    {
+        "id": "lrt2",
+        "colour": "#324a9c",
+        "fg": "#fff",
+        "name": {
+            "en": "LRT Line 2",
+            "zh-Hans": "LRT第2行",
+            "zh-Hant": "LRT第2行"
+        }
+    },
+    {
+        "id": "mrt3",
+        "colour": "#ffcc00",
+        "fg": "#fff",
+        "name": {
+            "en": "MRT Line 3",
+            "zh-Hans": "MRT第3行",
+            "zh-Hant": "MRT第3行"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Manila on behalf of Clarkmanuel0421.
This should fix #782

> @railmapgen/rmg-palette-resources@0.8.34 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

LRT Line 1: bg=`#01844b`, fg=`#fff`
LRT Line 2: bg=`#324a9c`, fg=`#fff`
MRT Line 3: bg=`#ffcc00`, fg=`#fff`