### PR TITLE
Resources: New palettes of Hong Kong

### DIFF
--- a/public/resources/palettes/hongkong.json
+++ b/public/resources/palettes/hongkong.json
@@ -121,7 +121,7 @@
     },
     {
         "id": "nol",
-        "colour": "#FF0066",
+        "colour": "#a1208a",
         "fg": "#fff",
         "name": {
             "en": "Northern Link",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Hong Kong on behalf of zam20070406.
This should fix #786

> @railmapgen/rmg-palette-resources@0.8.34 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Tsuen Wan Line: bg=`#E2231A`, fg=`#fff`
Kwun Tong Line: bg=`#00AF41`, fg=`#fff`
Island Line: bg=`#0071CE`, fg=`#fff`
Tseung Kwan O Line: bg=`#A35EB5`, fg=`#fff`
Tung Chung Line: bg=`#F38B00`, fg=`#fff`
Disney Resort Line: bg=`#E777CB`, fg=`#fff`
Airport Express: bg=`#007078`, fg=`#fff`
South Island Line (East): bg=`#B6BD00`, fg=`#fff`
South Island Line (West): bg=`#9182C2`, fg=`#fff`
East Kowloon Line: bg=`#006633`, fg=`#fff`
East Rail Line: bg=`#61B4E4`, fg=`#fff`
Tuen Ma Line: bg=`#9A3820`, fg=`#fff`
Northern Link: bg=`#a1208a`, fg=`#fff`
Light Rail: bg=`#CD9700`, fg=`#fff`
Light Rail Route 505: bg=`#DB1F26`, fg=`#fff`
Light Rail Route 507: bg=`#00A650`, fg=`#fff`
Light Rail Route 610: bg=`#431115`, fg=`#fff`
Light Rail Route 614: bg=`#4DC6F4`, fg=`#fff`
Light Rail Route 614P: bg=`#F46989`, fg=`#fff`
Light Rail Route 615: bg=`#FDDD04`, fg=`#fff`
Light Rail Route 615P: bg=`#215483`, fg=`#fff`
Light Rail Route 705: bg=`#64C542`, fg=`#fff`
Light Rail Route 706: bg=`#B365B9`, fg=`#fff`
Light Rail Route 751: bg=`#F47216`, fg=`#fff`
Light Rail Route 761/761P: bg=`#672290`, fg=`#fff`
Environmentally Friendly Linkage System: bg=`#000000`, fg=`#fff`
High Speed Rail: bg=`#9D968D`, fg=`#fff`
Ngong Ping 360: bg=`#94989A`, fg=`#fff`
Hong Kong Tramways: bg=`#007549`, fg=`#fff`
KCR East Rail: bg=`#005DA0`, fg=`#fff`
KCR West Rail: bg=`#AC2571`, fg=`#fff`
Ma On Shan Rail: bg=`#761E10`, fg=`#fff`
KCR Light Rail: bg=`#FD722D`, fg=`#fff`
West Rail Line: bg=`#B6008D`, fg=`#fff`