### PR TITLE
Resources: New palettes of Shenzhen

### DIFF
--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -208,5 +208,15 @@
             "zh-Hans": "坪山云巴",
             "zh-Hant": "坪山雲巴"
         }
+    },
+    {
+        "id": "sz17",
+        "colour": "#017d83",
+        "fg": "#fff",
+        "name": {
+            "en": "Line17",
+            "zh-Hans": "17号线",
+            "zh-Hant": "17号线"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenzhen on behalf of leepp2023.
This should fix #792

> @railmapgen/rmg-palette-resources@0.8.34 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1 (Luobao Line): bg=`#00B140`, fg=`#fff`
Line 2 (Shekou Line): bg=`#B94700`, fg=`#fff`
Line 3 (Longgang Line): bg=`#00A9E0`, fg=`#fff`
Line 4 (Longhua Line): bg=`#DA291C`, fg=`#fff`
Line 5 (Huanzhong Line): bg=`#A05EB5`, fg=`#fff`
Line 6: bg=`#00C7B1`, fg=`#fff`
Line 6 branch: bg=`#168773`, fg=`#fff`
Line 7: bg=`#0033A0`, fg=`#fff`
Line 8: bg=`#b94700`, fg=`#fff`
Line 9: bg=`#7B6469`, fg=`#fff`
Line 10: bg=`#F8779E`, fg=`#fff`
Line 11: bg=`#672146`, fg=`#fff`
Line 12: bg=`#A192B2`, fg=`#fff`
Line 13: bg=`#DE7C00`, fg=`#fff`
Line 14: bg=`#F2C75C`, fg=`#fff`
Line 15: bg=`#84BD00`, fg=`#fff`
Line 16: bg=`#1E22AA`, fg=`#fff`
Line 20: bg=`#88DBDF`, fg=`#fff`
Tram: bg=`#b8b8b8`, fg=`#fff`
Line 8 (Original): bg=`#E45DBF`, fg=`#fff`
Pingshan sky shuttlo: bg=`#1974d2`, fg=`#fff`
Line17: bg=`#017d83`, fg=`#fff`