### PR TITLE
Resources: New palettes of Nanjing

### DIFF
--- a/public/resources/palettes/nanjing.json
+++ b/public/resources/palettes/nanjing.json
@@ -11,7 +11,7 @@
     },
     {
         "id": "nj2",
-        "colour": "#c8003f",
+        "colour": "#a6093d",
         "fg": "#fff",
         "name": {
             "en": "Line 2",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanjing on behalf of njmetro-jxzb.
This should fix #798

> @railmapgen/rmg-palette-resources@1.0.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#009ace`, fg=`#fff`
Line 2: bg=`#a6093d`, fg=`#fff`
Line 3: bg=`#009a44`, fg=`#fff`
Line 4: bg=`#7d55c7`, fg=`#fff`
Line 5: bg=`#FDDA24`, fg=`#fff`
Line 6: bg=`#00b2a9`, fg=`#fff`
Line 7: bg=`#4A7729`, fg=`#fff`
Line 9: bg=`#fa4616`, fg=`#fff`
Line 10: bg=`#b9975b`, fg=`#fff`
Line 11: bg=`#ef426f`, fg=`#fff`
Line S1/Airport Line: bg=`#00b2a9`, fg=`#fff`
Line S3/Ninghe Line: bg=`#b06096`, fg=`#fff`
Line S4/Ningchu Line: bg=`#ff6314`, fg=`#fff`
Line S6/Ningju Line: bg=`#C98BDB`, fg=`#fff`
Line S7/Ningli Line: bg=`#e89cae`, fg=`#fff`
Line S8/Ningtian Line: bg=`#ea7600`, fg=`#fff`
Line S9/Ninggao Line: bg=`#f1b434`, fg=`#fff`