### PR TITLE
Resources: New palettes of Taipei

### DIFF
--- a/public/resources/palettes/taipei.json
+++ b/public/resources/palettes/taipei.json
@@ -131,7 +131,7 @@
     },
     {
         "id": "tr",
-        "colour": "#090980",
+        "colour": "#020281",
         "fg": "#fff",
         "name": {
             "en": "Taiwan Railways",

--- a/public/resources/palettes/taipei.json
+++ b/public/resources/palettes/taipei.json
@@ -128,5 +128,15 @@
             "zh-Hans": "猫空缆车",
             "zh-Hant": "貓空䌫車"
         }
+    },
+    {
+        "id": "tr",
+        "colour": "#090980",
+        "fg": "#fff",
+        "name": {
+            "en": "Taiwan Railways",
+            "zh-Hans": "台铁",
+            "zh-Hant": "台鐵"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Taipei on behalf of Takagi-Misae.
This should fix #800

> @railmapgen/rmg-palette-resources@1.0.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Wenhu Line (BR): bg=`#c48c31`, fg=`#fff`
Tamsui-Xinyi Line (R): bg=`#e3002c`, fg=`#fff`
Songshan-Xindian Line (G): bg=`#008659`, fg=`#fff`
Zhonghe-Xinlu Line (O): bg=`#f8b61c`, fg=`#000`
Bannan Line (BL): bg=`#0070bd`, fg=`#fff`
Circular Line (Y): bg=`#fedb00`, fg=`#000`
Xinbeitou Branch Line: bg=`#fd92a3`, fg=`#fff`
Xiaobitan Branch Line: bg=`#cfdb00`, fg=`#fff`
Wanda-Zhonghe-Shulin Line (LG): bg=`#a1d884`, fg=`#fff`
Minsheng-Xizhi Line: bg=`#25aae1`, fg=`#fff`
Donghu Branch Line: bg=`#283991`, fg=`#fff`
Shezi Line: bg=`#e40078`, fg=`#fff`
Maokong Gondola: bg=`#77bc1f`, fg=`#fff`
Taiwan Railways: bg=`#090980`, fg=`#fff`