### PR TITLE
Resources: New palettes of Shijiazhuang

### DIFF
--- a/public/resources/palettes/shijiazhuang.json
+++ b/public/resources/palettes/shijiazhuang.json
@@ -5,7 +5,8 @@
         "fg": "#fff",
         "name": {
             "en": "Line 1",
-            "zh-Hans": "1号线"
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線"
         }
     },
     {
@@ -14,7 +15,8 @@
         "fg": "#fff",
         "name": {
             "en": "Line 2",
-            "zh-Hans": "2号线"
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線"
         }
     },
     {
@@ -23,7 +25,8 @@
         "fg": "#fff",
         "name": {
             "en": "Line 3",
-            "zh-Hans": "3号线"
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shijiazhuang on behalf of BlueCatSkf.
This should fix #762

> @railmapgen/rmg-palette-resources@1.0.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#e53e30`, fg=`#fff`
Line 2: bg=`#fec30a`, fg=`#fff`
Line 3: bg=`#00a1e0`, fg=`#fff`