### PR TITLE
Resources: New palettes of Wuhu

### DIFF
--- a/public/resources/palettes/wuhu.json
+++ b/public/resources/palettes/wuhu.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "wh1",
-        "colour": "#ff0000",
+        "colour": "#e3002b",
         "fg": "#fff",
         "name": {
             "en": "Line 1",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wuhu on behalf of TPCpp.
This should fix #808

> @railmapgen/rmg-palette-resources@1.0.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#e3002b`, fg=`#fff`
Line 2: bg=`#4a86e8`, fg=`#fff`