### PR TITLE
Resources: New palettes of Genova

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -416,6 +416,15 @@
         }
     },
     {
+        "id": "genoa",
+        "country": "IT",
+        "name": {
+            "en": "Genoa",
+            "zh-Hans": "热那亚",
+            "zh-Hant": "熱那亞"
+        }
+    },
+    {
         "id": "glasgow",
         "country": "GBSCT",
         "name": {

--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -420,6 +420,7 @@
         "country": "IT",
         "name": {
             "en": "Genoa",
+            "it": "Genova",
             "zh-Hans": "热那亚",
             "zh-Hant": "熱那亞"
         }

--- a/public/resources/palettes/genoa.json
+++ b/public/resources/palettes/genoa.json
@@ -1,0 +1,57 @@
+[
+    {
+        "id": "m",
+        "colour": "#fb0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Metro",
+            "zh-Hans": "地铁",
+            "zh-Hant": "地鐵",
+            "it": "Metropolitana"
+        }
+    },
+    {
+        "id": "zl",
+        "colour": "#03c504",
+        "fg": "#fff",
+        "name": {
+            "en": "Zecca-Righi Funicular Railway",
+            "zh-Hans": "泽卡-里吉缆车铁路",
+            "zh-Hant": "澤卡-里吉纜車鐵路",
+            "it": "Funicolare Zecca-Righi"
+        }
+    },
+    {
+        "id": "sa",
+        "colour": "#027800",
+        "fg": "#fff",
+        "name": {
+            "en": "Sant'Anna Funicular Railway",
+            "zh-Hans": "圣安娜缆车铁路",
+            "zh-Hant": "聖安娜纜車鐵路",
+            "it": "Funicolare Sant'Anna"
+        }
+    },
+    {
+        "id": "fpg",
+        "colour": "#eac55d",
+        "fg": "#fff",
+        "name": {
+            "en": "Principe-Granarolo Rack Railway",
+            "zh-Hans": "普林西比-格拉那罗洛齿轨铁路",
+            "zh-Hant": "普林西比-格拉那羅洛齒軌鐵路",
+            "it": "Ferrovia a Cremagliera Principe-Granarolo"
+        }
+    },
+    {
+        "id": "gc",
+        "colour": "#be05c2",
+        "fg": "#fff",
+        "name": {
+            "en": "Genova-Casella Railway",
+            "zh-Hans": "热那亚-卡塞拉铁路",
+            "zh-Hant": "熱那亞-卡塞拉鐵路",
+            "it": "Ferrovia Genova-Casella"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Genova on behalf of polygon827.
This should fix #750

> @railmapgen/rmg-palette-resources@1.0.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Metro: bg=`#fb0000`, fg=`#fff`
Zecca-Righi Funicular Railway: bg=`#03c504`, fg=`#fff`
Sant'Anna Funicular Railway: bg=`#027800`, fg=`#fff`
Principe-Granarolo Rack Railway: bg=`#eac55d`, fg=`#fff`
Genova-Casella Railway: bg=`#be05c2`, fg=`#fff`