### PR TITLE
Resources: New palettes of Nanjing

### DIFF
--- a/public/resources/palettes/nanjing.json
+++ b/public/resources/palettes/nanjing.json
@@ -70,6 +70,16 @@
         }
     },
     {
+        "id": "8",
+        "colour": "#f6b402",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號線"
+        }
+    },
+    {
         "id": "nj9",
         "colour": "#fa4616",
         "fg": "#fff",
@@ -167,6 +177,26 @@
             "en": "Line S9/Ninggao Line",
             "zh-Hans": "S9号线/宁高线",
             "zh-Hant": "S9號線/寧高線"
+        }
+    },
+    {
+        "id": "nhmt",
+        "colour": "#47efff",
+        "fg": "#fff",
+        "name": {
+            "en": "Nanjing Hexi Modern Tram",
+            "zh-Hans": "南京河西有轨电车",
+            "zh-Hant": "南京河西有軌電車"
+        }
+    },
+    {
+        "id": "nqmt",
+        "colour": "#58c45b",
+        "fg": "#fff",
+        "name": {
+            "en": "Nanjing Qilin Modern Tram",
+            "zh-Hans": "南京麒麟有轨电车",
+            "zh-Hant": "南京河西有軌電車"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanjing on behalf of WIWO-ZHANG.
This should fix #844

> @railmapgen/rmg-palette-resources@2.0.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#009ace`, fg=`#fff`
Line 2: bg=`#c8003f`, fg=`#fff`
Line 3: bg=`#009a44`, fg=`#fff`
Line 4: bg=`#7d55c7`, fg=`#fff`
Line 5: bg=`#FDDA24`, fg=`#fff`
Line 6: bg=`#00b2a9`, fg=`#fff`
Line 7: bg=`#4A7729`, fg=`#fff`
Line 8: bg=`#f6b402`, fg=`#fff`
Line 9: bg=`#fa4616`, fg=`#fff`
Line 10: bg=`#b9975b`, fg=`#fff`
Line 11: bg=`#ef426f`, fg=`#fff`
Line S1/Airport Line: bg=`#00b2a9`, fg=`#fff`
Line S3/Ninghe Line: bg=`#b06096`, fg=`#fff`
Line S4/Ningchu Line: bg=`#ff6314`, fg=`#fff`
Line S6/Ningju Line: bg=`#C98BDB`, fg=`#fff`
Line S7/Ningli Line: bg=`#e89cae`, fg=`#fff`
Line S8/Ningtian Line: bg=`#ea7600`, fg=`#fff`
Line S9/Ninggao Line: bg=`#f1b434`, fg=`#fff`
Nanjing Hexi Modern Tram: bg=`#47efff`, fg=`#fff`
Nanjing Qilin Modern Tram: bg=`#58c45b`, fg=`#fff`