### PR TITLE
Resources: New palettes of Munich

### DIFF
--- a/public/resources/palettes/munich.json
+++ b/public/resources/palettes/munich.json
@@ -187,17 +187,6 @@
         }
     },
     {
-        "id": "ms20",
-        "colour": "#F05972",
-        "fg": "#fff",
-        "name": {
-            "en": "S20",
-            "de": "S20",
-            "zh-Hans": "市域S20（跨线运行）",
-            "zh-Hant": "市域S20（跨線運行）"
-        }
-    },
-    {
         "id": "ms27",
         "colour": "#f4929c",
         "fg": "#fff",
@@ -209,6 +198,17 @@
         }
     },
     {
+        "id": "ms20",
+        "colour": "#F05972",
+        "fg": "#fff",
+        "name": {
+            "en": "S20",
+            "de": "S20",
+            "zh-Hans": "市域S20（跨线运行）",
+            "zh-Hant": "市域S20（跨線運行）"
+        }
+    },
+    {
         "id": "mrz",
         "colour": "#313D85",
         "fg": "#fff",
@@ -217,6 +217,17 @@
             "de": "Regionalzug",
             "zh-Hans": "市域列车",
             "zh-Hant": "市域列車"
+        }
+    },
+    {
+        "id": "mu8",
+        "colour": "#cdc6b9",
+        "fg": "#fff",
+        "name": {
+            "en": "U8",
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號線",
+            "de": "U8"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Munich on behalf of axl099.
This should fix #850

> @railmapgen/rmg-palette-resources@2.0.1 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

U1: bg=`#438136`, fg=`#fff`
U2: bg=`#C40C37`, fg=`#fff`
U3: bg=`#F36E31`, fg=`#fff`
U4: bg=`#0AB38D`, fg=`#fff`
U5: bg=`#B8740E`, fg=`#fff`
U6: bg=`#006CB3`, fg=`#fff`
U7: bg=`#cec28b`, fg=`#fff`
U9: bg=`#009fe3`, fg=`#fff`
S1: bg=`#15BFE9`, fg=`#fff`
S2: bg=`#71BF44`, fg=`#fff`
S3: bg=`#90268F`, fg=`#fff`
S4: bg=`#EE1C28`, fg=`#fff`
S5: bg=`#ffcc00`, fg=`#000`
S6: bg=`#00975f`, fg=`#fff`
S7: bg=`#88322C`, fg=`#fff`
S8: bg=`#EFA83C`, fg=`#fff`
S10: bg=`#993333`, fg=`#fff`
S27: bg=`#f4929c`, fg=`#fff`
S20: bg=`#F05972`, fg=`#fff`
Regional Train: bg=`#313D85`, fg=`#fff`
U8: bg=`#cdc6b9`, fg=`#fff`