### PR TITLE
Resources: New palettes of Guangzhou

### DIFF
--- a/public/resources/palettes/guangzhou.json
+++ b/public/resources/palettes/guangzhou.json
@@ -240,6 +240,16 @@
         }
     },
     {
+        "id": "gz24",
+        "colour": "#1fada9",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 24",
+            "zh-Hans": "24号线",
+            "zh-Hant": "24號線"
+        }
+    },
+    {
         "id": "gfl",
         "colour": "#C4D600",
         "fg": "#000",
@@ -279,6 +289,16 @@
             "en": "Huangpu Tram Line 1",
             "zh-Hans": "黄埔有轨1号线",
             "zh-Hant": "黃埔有軌1號線"
+        }
+    },
+    {
+        "id": "thp2",
+        "colour": "#f15601",
+        "fg": "#fff",
+        "name": {
+            "en": "Huangpu Tram Line 2",
+            "zh-Hans": "黄埔有轨2号线",
+            "zh-Hant": "黃埔有軌2號線"
         }
     }
 ]

--- a/public/resources/palettes/guangzhou.json
+++ b/public/resources/palettes/guangzhou.json
@@ -293,7 +293,7 @@
     },
     {
         "id": "thp2",
-        "colour": "#f15601",
+        "colour": "#f25601",
         "fg": "#fff",
         "name": {
             "en": "Huangpu Tram Line 2",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Guangzhou on behalf of aaronyz2007.
This should fix #854

> @railmapgen/rmg-palette-resources@2.0.2 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Line 1: bg=`#F3D03E`, fg=`#000`
Line 2: bg=`#00629B`, fg=`#fff`
Line 3: bg=`#ECA154`, fg=`#fff`
Line 4: bg=`#00843D`, fg=`#fff`
Line 5: bg=`#C5003E`, fg=`#fff`
Line 6: bg=`#80225F`, fg=`#fff`
Line 7: bg=`#97D700`, fg=`#fff`
Line 8: bg=`#008C95`, fg=`#fff`
Line 9: bg=`#71CC98`, fg=`#000`
Line 10: bg=`#7D9CC0`, fg=`#fff`
Line 11: bg=`#470A68`, fg=`#fff`
Line 12: bg=`#59621D`, fg=`#fff`
Line 13: bg=`#8E8C13`, fg=`#fff`
Line 14: bg=`#81312F`, fg=`#fff`
Line 15: bg=`#AE8A79`, fg=`#fff`
Line 16: bg=`#9E652E`, fg=`#fff`
Line 17: bg=`#8B84D7`, fg=`#fff`
Line 18: bg=`#0047BA`, fg=`#fff`
Line 19: bg=`#BB29BB`, fg=`#fff`
Line 20: bg=`#D60078`, fg=`#fff`
Line 21: bg=`#211747`, fg=`#fff`
Line 22: bg=`#CD5228`, fg=`#fff`
Line 24: bg=`#1fada9`, fg=`#fff`
Guangfo Line: bg=`#C4D600`, fg=`#000`
APM Line: bg=`#00B5E2`, fg=`#fff`
Haizhu Tram Line 1: bg=`#43B02A`, fg=`#fff`
Huangpu Tram Line 1: bg=`#D42D1B`, fg=`#fff`
Huangpu Tram Line 2: bg=`#f15601`, fg=`#fff`