### PR TITLE
Resources: New palettes of Foshan

### DIFF
--- a/public/resources/palettes/foshan.json
+++ b/public/resources/palettes/foshan.json
@@ -1,93 +1,102 @@
 [
     {
         "id": "fs1",
+        "colour": "#C4D600",
+        "fg": "#000",
         "name": {
             "en": "Guangfo Line",
             "zh-Hans": "广佛线",
             "zh-Hant": "廣佛線"
-        },
-        "colour": "#C4D600",
-        "fg": "#000"
+        }
     },
     {
         "id": "fs2",
+        "colour": "#F5333F",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#F5333F"
+        }
     },
     {
         "id": "fs3",
+        "colour": "#002F87",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#002F87"
+        }
     },
     {
         "id": "fs4",
+        "colour": "#923A7F",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#923A7F"
+        }
     },
     {
         "id": "fs6",
+        "colour": "#FFB81D",
+        "fg": "#fff",
         "name": {
             "en": "Line 6",
             "zh-Hans": "6号线",
             "zh-Hant": "6號線"
-        },
-        "colour": "#FFB81D"
+        }
     },
     {
         "id": "fs9",
+        "colour": "#A25EB5",
+        "fg": "#fff",
         "name": {
             "en": "Line 9",
             "zh-Hans": "9号线",
             "zh-Hant": "9號線"
-        },
-        "colour": "#A25EB5"
+        }
     },
     {
         "id": "fs11",
+        "colour": "#2a3976",
+        "fg": "#fff",
         "name": {
             "en": "Line 11",
             "zh-Hans": "11号线",
             "zh-Hant": "11號線"
-        },
-        "colour": "#035C67"
+        }
     },
     {
         "id": "fs13",
+        "colour": "#32B7EA",
+        "fg": "#fff",
         "name": {
             "en": "Line 13",
             "zh-Hans": "13号线",
             "zh-Hant": "13號線"
-        },
-        "colour": "#32B7EA"
+        }
     },
     {
         "id": "tnh1",
+        "colour": "#5EB3E4",
+        "fg": "#fff",
         "name": {
             "en": "Nanhai Tram Line 1",
             "zh-Hans": "南海有轨1号线",
             "zh-Hant": "南海有軌1號線"
-        },
-        "colour": "#5EB3E4"
+        }
     },
     {
         "id": "tgm1",
+        "colour": "#4CA585",
+        "fg": "#fff",
         "name": {
             "en": "Gaoming Tram Line 1",
             "zh-Hans": "高明有轨1号线",
             "zh-Hant": "高明有軌1號線"
-        },
-        "colour": "#4CA585"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Foshan on behalf of aaronyz2007.
This should fix #856

> @railmapgen/rmg-palette-resources@2.0.2 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

Guangfo Line: bg=`#C4D600`, fg=`#000`
Line 2: bg=`#F5333F`, fg=`#fff`
Line 3: bg=`#002F87`, fg=`#fff`
Line 4: bg=`#923A7F`, fg=`#fff`
Line 6: bg=`#FFB81D`, fg=`#fff`
Line 9: bg=`#A25EB5`, fg=`#fff`
Line 11: bg=`#2a3976`, fg=`#fff`
Line 13: bg=`#32B7EA`, fg=`#fff`
Nanhai Tram Line 1: bg=`#5EB3E4`, fg=`#fff`
Gaoming Tram Line 1: bg=`#4CA585`, fg=`#fff`