### PR TITLE
Resources: New palettes of Expressway

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -387,6 +387,15 @@
         }
     },
     {
+        "id": "expressway",
+        "country": "CN",
+        "name": {
+            "en": "Expressway",
+            "zh": "高速公路",
+            "zh-HK": "高速公路"
+        }
+    },
+    {
         "id": "foshan",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/expressway.json
+++ b/public/resources/palettes/expressway.json
@@ -1,0 +1,72 @@
+[
+    {
+        "id": "expresswayn",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "National expressway",
+            "zh-Hans": "国家高速",
+            "zh-Hant": "國家高速"
+        }
+    },
+    {
+        "id": "expresswayp",
+        "colour": "#ffff00",
+        "fg": "#000",
+        "name": {
+            "en": "Province expressway",
+            "zh-Hans": "省级高速",
+            "zh-Hant": "省級高速"
+        }
+    },
+    {
+        "id": "expresswaynh",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "National Highway",
+            "zh-Hans": "国道",
+            "zh-Hant": "國道"
+        }
+    },
+    {
+        "id": "expresswayj",
+        "colour": "#ccff33",
+        "fg": "#000",
+        "name": {
+            "en": "Jingjinji expressway",
+            "zh-Hans": "京津冀高速",
+            "zh-Hant": "京津冀高速"
+        }
+    },
+    {
+        "id": "expresswayph",
+        "colour": "#ffff00",
+        "fg": "#000",
+        "name": {
+            "en": "Province Highway",
+            "zh-Hans": "省道",
+            "zh-Hant": "省道"
+        }
+    },
+    {
+        "id": "expresswaycr",
+        "colour": "#ffffff",
+        "fg": "#000",
+        "name": {
+            "en": "County road",
+            "zh-Hans": "县道",
+            "zh-Hant": "縣道"
+        }
+    },
+    {
+        "id": "expresswayy",
+        "colour": "#ffffff",
+        "fg": "#000",
+        "name": {
+            "en": "Country road",
+            "zh-Hans": "乡道",
+            "zh-Hant": "鄉道"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Expressway on behalf of LittleLing03.
This should fix #448

> @railmapgen/rmg-palette-resources@2.0.2 issuebot
> node --loader ts-node/esm ./issuebot/issuebot.ts

Printing all colours...

National expressway: bg=`#ff0000`, fg=`#fff`
Province expressway: bg=`#ffff00`, fg=`#000`
National Highway: bg=`#ff0000`, fg=`#fff`
Jingjinji expressway: bg=`#ccff33`, fg=`#000`
Province Highway: bg=`#ffff00`, fg=`#000`
County road: bg=`#ffffff`, fg=`#000`
Country road: bg=`#ffffff`, fg=`#000`