### PR TITLE
Resources: New palettes of Jinhua

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -609,6 +609,15 @@
         }
     },
     {
+        "id": "jinhua",
+        "country": "CN",
+        "name": {
+            "en": "Jinhua",
+            "zh-Hans": "金华",
+            "zh-Hant": "金華"
+        }
+    },
+    {
         "id": "kansai",
         "country": "JP",
         "name": {

--- a/public/resources/palettes/jinhua.json
+++ b/public/resources/palettes/jinhua.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "jydline",
+        "colour": "#da1934",
+        "fg": "#fff",
+        "name": {
+            "en": "Jinhua-Yiwu-Dongyang Line",
+            "zh-Hans": "金义东线",
+            "zh-Hant": "金義東線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Jinhua on behalf of DQB061204.
This should fix #869

> @railmapgen/rmg-palette-resources@2.1.0 issuebot
> ts-node issuebot/issuebot.mts

Printing all colours...

Jinhua-Yiwu-Dongyang Line: bg=`#da1934`, fg=`#fff`