### PR TITLE
Resources: New palettes of Sendai

### DIFF
--- a/public/resources/palettes/sendai.json
+++ b/public/resources/palettes/sendai.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": "sdn",
+        "id": "n",
         "colour": "#317c66",
         "fg": "#fff",
         "name": {
@@ -12,7 +12,7 @@
         }
     },
     {
-        "id": "sdt",
+        "id": "t",
         "colour": "#00b1dd",
         "fg": "#fff",
         "name": {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Sendai on behalf of HUQIUAN.
This should fix #875

> @railmapgen/rmg-palette-resources@2.1.1 issuebot
> ts-node issuebot/issuebot.mts

Printing all colours...

Namboku Line (N): bg=`#317c66`, fg=`#fff`
Tozai Line (T): bg=`#00b1dd`, fg=`#fff`