### PR TITLE
Resources: New palettes of Wuhan

### DIFF
--- a/public/resources/palettes/wuhan.json
+++ b/public/resources/palettes/wuhan.json
@@ -158,5 +158,45 @@
             "zh-Hans": "21号线",
             "zh-Hant": "21號線"
         }
+    },
+    {
+        "id": "whggkg",
+        "colour": "#05aff1",
+        "fg": "#fff",
+        "name": {
+            "en": "Suspended Monorail Line",
+            "zh-Hans": "空轨旅游线",
+            "zh-Hant": "空軌旅遊線"
+        }
+    },
+    {
+        "id": "whggxdygdcl1",
+        "colour": "#0000ff",
+        "fg": "#fff",
+        "name": {
+            "en": "Wuhan Optics Valley Modern Tram Line 1",
+            "zh-Hans": "武汉光谷现代有轨电车1号线",
+            "zh-Hant": "武漢光谷現代電車1號線"
+        }
+    },
+    {
+        "id": "whggxdygdcl2",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Wuhan Optics Valley Modern Tram Line 2",
+            "zh-Hans": "武汉光谷现代有轨电车2号线",
+            "zh-Hant": "武漢光谷現代電車2號線"
+        }
+    },
+    {
+        "id": "whggxdygdcl5",
+        "colour": "#818181",
+        "fg": "#fff",
+        "name": {
+            "en": "Wuhan Optics Valley Modern Tram Line 5 (Event Time Only)",
+            "zh-Hans": "武汉光谷现代有轨电车5号线（大型活动开行）",
+            "zh-Hant": "武漢光谷現代電車5號線（大型活動開行）"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wuhan on behalf of DQB061204.
This should fix #877

> @railmapgen/rmg-palette-resources@2.1.1 issuebot
> ts-node issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#3D84C6`, fg=`#fff`
Line 2: bg=`#EB7CAF`, fg=`#fff`
Line 3: bg=`#D9B966`, fg=`#fff`
Line 4: bg=`#8EC720`, fg=`#fff`
Line 5: bg=`#a62e37`, fg=`#fff`
Line 6: bg=`#008536`, fg=`#fff`
Line 7: bg=`#EB7900`, fg=`#fff`
Line 8: bg=`#98ACAB`, fg=`#fff`
Line 9: bg=`#A5D4AD`, fg=`#fff`
Line 10: bg=`#8C3626`, fg=`#fff`
Line 11: bg=`#F2CF01`, fg=`#fff`
Line 12: bg=`#00A3E9`, fg=`#fff`
Line 13: bg=`#25CAD0`, fg=`#fff`
Line 14: bg=`#7D55A3`, fg=`#fff`
Line 16: bg=`#CC0256`, fg=`#fff`
Line 21: bg=`#CF0192`, fg=`#fff`
Suspended Monorail Line: bg=`#05aff1`, fg=`#fff`
Wuhan Optics Valley Modern Tram Line 1: bg=`#0000ff`, fg=`#fff`
Wuhan Optics Valley Modern Tram Line 2: bg=`#ff0000`, fg=`#fff`
Wuhan Optics Valley Modern Tram Line 5 (Event Time Only): bg=`#818181`, fg=`#fff`