### PR TITLE
Resources: New palettes of Hangzhou

### DIFF
--- a/public/resources/palettes/hangzhou.json
+++ b/public/resources/palettes/hangzhou.json
@@ -100,6 +100,26 @@
         }
     },
     {
+        "id": "hz12",
+        "colour": "#00778f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 12",
+            "zh-Hans": "12号线",
+            "zh-Hant": "12號線"
+        }
+    },
+    {
+        "id": "hz15",
+        "colour": "#fe86de",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 15",
+            "zh-Hans": "15号线",
+            "zh-Hant": "15號線"
+        }
+    },
+    {
         "id": "hz16",
         "colour": "#ffaa52",
         "fg": "#fff",
@@ -107,6 +127,16 @@
             "en": "Line 16",
             "zh-Hans": "16号线",
             "zh-Hant": "16號線"
+        }
+    },
+    {
+        "id": "hz18",
+        "colour": "#71fe71",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 18",
+            "zh-Hans": "18号线",
+            "zh-Hant": "18號線"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Hangzhou on behalf of HangzhouMetro.
This should fix #886

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#e8384a`, fg=`#fff`
Line 2: bg=`#e17901`, fg=`#fff`
Line 3: bg=`#ffcf23`, fg=`#000`
Line 4: bg=`#60c04b`, fg=`#fff`
Line 5: bg=`#00afc8`, fg=`#fff`
Line 6: bg=`#0077cf`, fg=`#fff`
Line 7: bg=`#790f8e`, fg=`#fff`
Line 8: bg=`#a80d4d`, fg=`#fff`
Line 9: bg=`#c45b03`, fg=`#fff`
Line 10: bg=`#daaa00`, fg=`#fff`
Line 12: bg=`#00778f`, fg=`#fff`
Line 15: bg=`#fe86de`, fg=`#fff`
Line 16: bg=`#ffaa52`, fg=`#fff`
Line 18: bg=`#71fe71`, fg=`#fff`
Line 19: bg=`#4acbe5`, fg=`#fff`