### PR TITLE
Resources: New palettes of Suzhou

### DIFF
--- a/public/resources/palettes/suzhou.json
+++ b/public/resources/palettes/suzhou.json
@@ -118,5 +118,35 @@
             "zh-Hans": "未开通线路",
             "zh-Hant": "未開通線路"
         }
+    },
+    {
+        "id": "szy1",
+        "colour": "#84b47d",
+        "fg": "#fff",
+        "name": {
+            "en": "SND Tram Line 1",
+            "zh-Hans": "苏州高新有轨电车1号线",
+            "zh-Hant": "蘇州高新有軌電車1號線"
+        }
+    },
+    {
+        "id": "szy2",
+        "colour": "#7a0702",
+        "fg": "#fff",
+        "name": {
+            "en": "SND Tram Line 2",
+            "zh-Hans": "苏州高新有轨电车2号线",
+            "zh-Hant": "蘇州高新有軌電車2號線"
+        }
+    },
+    {
+        "id": "szy5",
+        "colour": "#490a69",
+        "fg": "#fff",
+        "name": {
+            "en": "SND Tram Line 5",
+            "zh-Hans": "苏州高新有轨电车5号线",
+            "zh-Hant": "蘇州高新有軌電車5號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Suzhou on behalf of beiguangrailtransit.
This should fix #894

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#78BA25`, fg=`#fff`
Line 2: bg=`#ED3240`, fg=`#fff`
Line 3: bg=`#F88211`, fg=`#fff`
Line 4: bg=`#196EAE`, fg=`#fff`
Line 5: bg=`#E63A9A`, fg=`#fff`
Line 6: bg=`#41b6e6`, fg=`#fff`
Line 7: bg=`#a77bca`, fg=`#fff`
Line 8: bg=`#a09200`, fg=`#fff`
Line 10: bg=`#ca9a8e`, fg=`#fff`
Line 11: bg=`#f1c6a6`, fg=`#fff`
Tram: bg=`#d8e4c0`, fg=`#fff`
Lines under construction: bg=`#dddddd`, fg=`#fff`
SND Tram Line 1: bg=`#84b47d`, fg=`#fff`
SND Tram Line 2: bg=`#7a0702`, fg=`#fff`
SND Tram Line 5: bg=`#490a69`, fg=`#fff`