### PR TITLE
Resources: New palettes of Hangzhou

### DIFF
--- a/public/resources/palettes/hangzhou.json
+++ b/public/resources/palettes/hangzhou.json
@@ -118,5 +118,15 @@
             "zh-Hans": "19号线",
             "zh-Hant": "19號線"
         }
+    },
+    {
+        "id": "hangzhouhainingintercityrail",
+        "colour": "#0277c8",
+        "fg": "#fff",
+        "name": {
+            "en": "Hangzhou-Haining Intercity Rail",
+            "zh-Hans": "杭海城际",
+            "zh-Hant": "杭海城際"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Hangzhou on behalf of Windows-Taskmgr.
This should fix #896

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#e8384a`, fg=`#fff`
Line 2: bg=`#e17901`, fg=`#fff`
Line 3: bg=`#ffcf23`, fg=`#000`
Line 4: bg=`#60c04b`, fg=`#fff`
Line 5: bg=`#00afc8`, fg=`#fff`
Line 6: bg=`#0077cf`, fg=`#fff`
Line 7: bg=`#790f8e`, fg=`#fff`
Line 8: bg=`#a80d4d`, fg=`#fff`
Line 9: bg=`#c45b03`, fg=`#fff`
Line 10: bg=`#daaa00`, fg=`#fff`
Line 16: bg=`#ffaa52`, fg=`#fff`
Line 19: bg=`#4acbe5`, fg=`#fff`
Hangzhou-Haining Intercity Rail: bg=`#0277c8`, fg=`#fff`