### PR TITLE
Resources: New palettes of Tokyo (Greater Tokyo Area)

### DIFF
--- a/public/resources/palettes/tokyo.json
+++ b/public/resources/palettes/tokyo.json
@@ -823,5 +823,27 @@
             "zh-Hans": "川越线",
             "zh-Hant": "川越線"
         }
+    },
+    {
+        "id": "tx",
+        "colour": "#003b83",
+        "fg": "#fff",
+        "name": {
+            "en": "Tsukuba Express",
+            "zh-Hans": "筑波快线",
+            "zh-Hant": "筑波快線",
+            "ja": "つくばエクスプレス"
+        }
+    },
+    {
+        "id": "ss",
+        "colour": "#00a7bf",
+        "fg": "#fff",
+        "name": {
+            "en": "Haijima Line",
+            "zh-Hans": "拜岛线",
+            "zh-Hant": "拜島線",
+            "ja": "拝島線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Tokyo (Greater Tokyo Area) on behalf of Charlis-Wong.
This should fix #902

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Ginza Line (G): bg=`#f9a328`, fg=`#fff`
Marunouchi Line (M): bg=`#d92c2f`, fg=`#fff`
Hibiya Line (H): bg=`#c7beb3`, fg=`#fff`
Tōzai Line (T): bg=`#00a4db`, fg=`#fff`
Chiyoda Line (C): bg=`#1bb267`, fg=`#fff`
Yūrakuchō Line (Y): bg=`#d1a662`, fg=`#fff`
Hanzōmon Line (Z): bg=`#8c7dba`, fg=`#fff`
Namboku Line (N): bg=`#02b69b`, fg=`#fff`
Fukutoshin Line (F): bg=`#9c5e31`, fg=`#fff`
Asakusa Line (A): bg=`#dd4231`, fg=`#fff`
Mita Line (I): bg=`#0068a5`, fg=`#fff`
Shinjuku Line (S): bg=`#abba41`, fg=`#fff`
Ōedo Line (O): bg=`#ce1c64`, fg=`#fff`
Yamanote Line (JY): bg=`#7bab4f`, fg=`#000`
Keihin-Tōhoku Line/Negishi Line (JK): bg=`#00b2e6`, fg=`#fff`
Chūō Line/Sōbu Line (Local) (JB): bg=`#fed304`, fg=`#000`
Chūō Line (Rapid)/Chūō Line/Ōme Line/Itsukaichi Line (JC): bg=`#f15921`, fg=`#fff`
Yokosuka Line/Sōbu Line (Rapid)/Sōbu Line/Narita Line (JO): bg=`#007ac0`, fg=`#fff`
Utsunomiya Line/Takasaki Line (JU): bg=`#f68b1f`, fg=`#fff`
Tōkaidō Line/Itō Line (JT): bg=`#f68b1f`, fg=`#fff`
Saikyō Line (JA): bg=`#0ab38d`, fg=`#fff`
Shōnan-Shinjuku Line (JS): bg=`#DB2027`, fg=`#fff`
Jōban Line (Rapid) (JJ): bg=`#1DAF7E`, fg=`#fff`
Jōban Line (Local) (JL): bg=`#868587`, fg=`#fff`
Keiyō Line (JE): bg=`#D01827`, fg=`#fff`
Yokohama Line (JH): bg=`#B1CB39`, fg=`#fff`
Musashino Line (JM): bg=`#EB5A28`, fg=`#fff`
Nambu Line (JN): bg=`#F2D01F`, fg=`#fff`
Tsurumi Line (JI): bg=`#F2D01F`, fg=`#fff`
Tokyo Monorail Haneda Airport Line (MO): bg=`#26326A`, fg=`#fff`
Yokohama Municipal Subway Blue Line (B): bg=`#2F56A5`, fg=`#fff`
Yokohama Municipal Subway Green Line (G): bg=`#28846E`, fg=`#fff`
Tōkyū Tōyoko Line (TY): bg=`#DA0042`, fg=`#fff`
Tōkyū Meguro Line (MG): bg=`#009CD3`, fg=`#fff`
Tōkyū Den-en-toshi Line (DT): bg=`#00AA8D`, fg=`#fff`
Tōkyū Ōimachi Line (OM): bg=`#F18C43`, fg=`#fff`
Tōkyū Ikegami Line (IK): bg=`#EE86A8`, fg=`#fff`
Tōkyū Tamagawa Line (TM): bg=`#AE0079`, fg=`#fff`
Kodomonokuni Line (KD): bg=`#0071BE`, fg=`#fff`
Tōkyū Setagaya Line (SG): bg=`#FCC800`, fg=`#fff`
Seibu Ikebukuro Line (SI): bg=`#EF7A00`, fg=`#fff`
Seibu Shinjuku Line (SS): bg=`#00A6BF`, fg=`#fff`
Seibu Kokubunji Line (SK): bg=`#38b35c`, fg=`#fff`
Seibu Tamagawa Line (SW): bg=`#f17c24`, fg=`#fff`
Seibu Tamako Line (ST): bg=`#f7aa2c`, fg=`#fff`
Seibu Yamaguchi Line (SY): bg=`#ec4840`, fg=`#fff`
Tōbu Skytree Line (TS): bg=`#006CBA`, fg=`#fff`
Tōbu Isesaki Line (TI): bg=`#E61919`, fg=`#fff`
Tōbu Nikkō Line (TN): bg=`#F5A200`, fg=`#fff`
Tōbu Urban Park Line (TD): bg=`#40B4E5`, fg=`#fff`
Tōbu Tōjō Line (TJ): bg=`#00428E`, fg=`#fff`
Keisei Main Line (KS): bg=`#005AAA`, fg=`#fff`
Keisei Narita Airport Line (KS): bg=`#FF8620`, fg=`#fff`
Shin-Keisei Line (SL): bg=`#EF59A1`, fg=`#fff`
Hokusō Line (HS): bg=`#00bdf2`, fg=`#fff`
Shibayama Railway Line (SR): bg=`#00A650`, fg=`#fff`
Odakyū Lines (OH/OE/OT): bg=`#0085CE`, fg=`#fff`
Keiō Line (KO): bg=`#D5007F`, fg=`#fff`
Keiō Inokashira Line (IN): bg=`#103675`, fg=`#fff`
Keikyū Main Line (KK): bg=`#00BFFF`, fg=`#fff`
Sōtetsu Main Line (SO): bg=`#0071C1`, fg=`#fff`
Rinkai Line (R): bg=`#00418e`, fg=`#fff`
New Transit Yurikamome (U): bg=`#1662B8`, fg=`#fff`
Tokyo Sakura Tram (SA): bg=`#d75b80`, fg=`#fff`
Nippori-Toneri Liner (NT): bg=`#D53A77`, fg=`#fff`
Minatomirai Line (MM): bg=`#19559F`, fg=`#fff`
Enoshima Dentetsu Line (EN): bg=`#f6be18`, fg=`#fff`
Tōyō Rapid Railway Line (TR): bg=`#5AB65C`, fg=`#fff`
Saitama Rapid Railway Line (SR): bg=`#3564AF`, fg=`#fff`
Tama Toshi Monorail Line: bg=`#27625E`, fg=`#fff`
Ina Line (NS): bg=`#18A698`, fg=`#fff`
Chōshi Electric Railway Line (CD): bg=`#a52a2a`, fg=`#fff`
Chiba Urban Monorail (CM): bg=`#2843ba`, fg=`#fff`
Hachiko Line: bg=`#a09d95`, fg=`#fff`
Kawagoe Line: bg=`#a6a9ab`, fg=`#fff`
Tsukuba Express: bg=`#003b83`, fg=`#fff`
Haijima Line: bg=`#00a7bf`, fg=`#fff`