### PR TITLE
Resources: New palettes of Taizhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1431,6 +1431,15 @@
         }
     },
     {
+        "id": "taizhou",
+        "country": "CN",
+        "name": {
+            "en": "Taizhou",
+            "zh-Hans": "台州",
+            "zh-Hant": "臺州"
+        }
+    },
+    {
         "id": "taoyuan",
         "country": "TW",
         "name": {

--- a/public/resources/palettes/taizhou.json
+++ b/public/resources/palettes/taizhou.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "ta S1",
+        "colour": "#0099db",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh-Hans": "S1线",
+            "zh-Hant": "S1線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Taizhou on behalf of Xiao-qian111.
This should fix #907

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line S1: bg=`#0099db`, fg=`#fff`