### PR TITLE
Resources: New palettes of Lakeland

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -764,6 +764,14 @@
         }
     },
     {
+        "id": "ll",
+        "country": "",
+        "name": {
+            "en": "Lakeland",
+            "zh-Hant": "湖邊鎮"
+        }
+    },
+    {
         "id": "london",
         "country": "GBENG",
         "name": {

--- a/public/resources/palettes/ll.json
+++ b/public/resources/palettes/ll.json
@@ -1,0 +1,137 @@
+[
+    {
+        "id": "WF",
+        "colour": "#3048e1",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1 Waterfront",
+            "zh-Hant": "湖邊 1線"
+        }
+    },
+    {
+        "id": "QU",
+        "colour": "#80acff",
+        "fg": "#000",
+        "name": {
+            "en": "Line 1A Quay Tram",
+            "zh-Hant": "電車 1A線"
+        }
+    },
+    {
+        "id": "NO",
+        "colour": "#f00018",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2 North City",
+            "zh-Hant": "北都 2線"
+        }
+    },
+    {
+        "id": "SO",
+        "colour": "#ffe124",
+        "fg": "#000",
+        "name": {
+            "en": "Line 3 South City",
+            "zh-Hant": "南都 3線"
+        }
+    },
+    {
+        "id": "AA",
+        "colour": "#80e130",
+        "fg": "#000",
+        "name": {
+            "en": "Line 4 Acacia",
+            "zh-Hant": "合金歡 4線"
+        }
+    },
+    {
+        "id": "VL",
+        "colour": "#d648d6",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5 Valiance",
+            "zh-Hant": "剛毅 5線"
+        }
+    },
+    {
+        "id": "SR",
+        "colour": "#ff9648",
+        "fg": "#000",
+        "name": {
+            "en": "Line 6 Sunrise",
+            "zh-Hant": "日昇 6線"
+        }
+    },
+    {
+        "id": "TB",
+        "colour": "#48b448",
+        "fg": "#000",
+        "name": {
+            "en": "Line 7 Thistlebough",
+            "zh-Hant": "尖薊田 7線"
+        }
+    },
+    {
+        "id": "IL",
+        "colour": "#acf0ac",
+        "fg": "#000",
+        "name": {
+            "en": "Line 7A Island Shuttle",
+            "zh-Hant": "離島 7A線"
+        }
+    },
+    {
+        "id": "AE",
+        "colour": "#96e1f0",
+        "fg": "#000",
+        "name": {
+            "en": "Line 8 Airport Express",
+            "zh-Hant": "機場快線 8線"
+        }
+    },
+    {
+        "id": "NC",
+        "colour": "#ffc8f0",
+        "fg": "#000",
+        "name": {
+            "en": "Line 9 North City Circular",
+            "zh-Hant": "北都循環 9線"
+        }
+    },
+    {
+        "id": "LR",
+        "colour": "#d6b450",
+        "fg": "#000",
+        "name": {
+            "en": "Line 10 ELRIC",
+            "zh-Hant": "輕鐵 10線"
+        }
+    },
+    {
+        "id": "GC",
+        "colour": "#964818",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 11 Grove Corridor",
+            "zh-Hant": "叢林道 11線"
+        }
+    },
+    {
+        "id": "NS",
+        "colour": "#e1e1e1",
+        "fg": "#000",
+        "name": {
+            "en": "Line S1 North Suburban",
+            "zh-Hant": "北都近郊 S1線"
+        }
+    },
+    {
+        "id": "SS",
+        "colour": "#808080",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S2 South Suburban",
+            "zh-Hant": "南都近郊 S2線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Lakeland on behalf of dingusdono.
This should fix #913

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1 Waterfront: bg=`#3048e1`, fg=`#fff`
Line 1A Quay Tram: bg=`#80acff`, fg=`#000`
Line 2 North City: bg=`#f00018`, fg=`#fff`
Line 3 South City: bg=`#ffe124`, fg=`#000`
Line 4 Acacia: bg=`#80e130`, fg=`#000`
Line 5 Valiance: bg=`#d648d6`, fg=`#fff`
Line 6 Sunrise: bg=`#ff9648`, fg=`#000`
Line 7 Thistlebough: bg=`#48b448`, fg=`#000`
Line 7A Island Shuttle: bg=`#acf0ac`, fg=`#000`
Line 8 Airport Express: bg=`#96e1f0`, fg=`#000`
Line 9 North City Circular: bg=`#ffc8f0`, fg=`#000`
Line 10 ELRIC: bg=`#d6b450`, fg=`#000`
Line 11 Grove Corridor: bg=`#964818`, fg=`#fff`
Line S1 North Suburban: bg=`#e1e1e1`, fg=`#000`
Line S2 South Suburban: bg=`#808080`, fg=`#fff`