### PR TITLE
Resources: New palettes of Kyoto

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -695,6 +695,16 @@
         }
     },
     {
+        "id": "kyoto",
+        "country": "JP",
+        "name": {
+            "en": "Kyoto",
+            "zh-Hans": "京都",
+            "zh-Hant": "京都",
+            "ja": "京都"
+        }
+    },
+    {
         "id": "lahore",
         "country": "PK",
         "name": {

--- a/public/resources/palettes/kyoto.json
+++ b/public/resources/palettes/kyoto.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "ktt",
+        "colour": "#ff4500",
+        "fg": "#fff",
+        "name": {
+            "en": "Tozai Line",
+            "zh-Hans": "东西线",
+            "zh-Hant": "東西綫",
+            "ja": "東西線"
+        }
+    },
+    {
+        "id": "ktk",
+        "colour": "#3cb371",
+        "fg": "#fff",
+        "name": {
+            "en": "Karasuma Line",
+            "zh-Hans": "鸟丸线",
+            "zh-Hant": "鳥丸綫",
+            "ja": "烏丸線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Kyoto on behalf of axl099.
This should fix #924

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Tozai Line: bg=`#ff4500`, fg=`#fff`
Karasuma Line: bg=`#3cb371`, fg=`#fff`