### PR TITLE
Resources: New palettes of Strasbourg

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1397,6 +1397,16 @@
         }
     },
     {
+        "id": "strasbourg",
+        "country": "FR",
+        "name": {
+            "en": "Strasbourg",
+            "zh-Hans": "斯特拉斯堡",
+            "zh-Hant": "斯特拉斯堡",
+            "fr": "Strasbourg"
+        }
+    },
+    {
         "id": "suzhou",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/strasbourg.json
+++ b/public/resources/palettes/strasbourg.json
@@ -1,0 +1,90 @@
+[
+    {
+        "id": "sta",
+        "colour": "#e41513",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line A",
+            "zh-Hans": "电车A线",
+            "zh-Hant": "電車A缐",
+            "fr": "Tram Ligne A"
+        }
+    },
+    {
+        "id": "stb",
+        "colour": "#009fe3",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line B",
+            "zh-Hans": "电车B线",
+            "zh-Hant": "電車B缐",
+            "fr": "Tram Ligne B"
+        }
+    },
+    {
+        "id": "stc",
+        "colour": "#f19200",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line C",
+            "zh-Hans": "电车C线",
+            "zh-Hant": "電車C缐",
+            "fr": "Tram Ligne C"
+        }
+    },
+    {
+        "id": "std",
+        "colour": "#009e3d",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line D",
+            "zh-Hans": "电车D线",
+            "zh-Hant": "電車D缐",
+            "fr": "Tram Ligne D"
+        }
+    },
+    {
+        "id": "ste",
+        "colour": "#9185be",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line E",
+            "zh-Hans": "电车E线",
+            "zh-Hant": "電車E缐",
+            "fr": "Tram Ligne E"
+        }
+    },
+    {
+        "id": "stf",
+        "colour": "#95c01f",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line F",
+            "zh-Hans": "电车F线",
+            "zh-Hant": "電車F缐",
+            "fr": "Tram Ligne F"
+        }
+    },
+    {
+        "id": "sbg",
+        "colour": "#294294",
+        "fg": "#fff",
+        "name": {
+            "en": "Bus Line G",
+            "zh-Hans": "巴士G线",
+            "zh-Hant": "巴士G缐",
+            "fr": "Bus Ligne G"
+        }
+    },
+    {
+        "id": "sbh",
+        "colour": "#a62241",
+        "fg": "#fff",
+        "name": {
+            "en": "Bus Line H",
+            "zh-Hans": "巴士H线",
+            "zh-Hant": "巴士H缐",
+            "fr": "Bus Ligne H"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Strasbourg on behalf of linchen1965.
This should fix #926

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Tram Line A: bg=`#e41513`, fg=`#fff`
Tram Line B: bg=`#009fe3`, fg=`#fff`
Tram Line C: bg=`#f19200`, fg=`#fff`
Tram Line D: bg=`#009e3d`, fg=`#fff`
Tram Line E: bg=`#9185be`, fg=`#fff`
Tram Line F: bg=`#95c01f`, fg=`#fff`
Bus Line G: bg=`#294294`, fg=`#fff`
Bus Line H: bg=`#a62241`, fg=`#fff`