### PR TITLE
Resources: New palettes of Bandung

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -49,6 +49,16 @@
         }
     },
     {
+        "id": "b",
+        "country": "ID",
+        "name": {
+            "id": "Bandung",
+            "en": "Bandung",
+            "zh-Hans": "万隆",
+            "zh-Hant": "萬隆"
+        }
+    },
+    {
         "id": "baku",
         "country": "AZ",
         "name": {

--- a/public/resources/palettes/b.json
+++ b/public/resources/palettes/b.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": "jbhs",
+        "colour": "#404040",
+        "fg": "#fff",
+        "name": {
+            "en": "Jakarta Bandung High Speed",
+            "zh-Hans": "到中国传统的",
+            "zh-Hant": " 到中國傳統的",
+            "id": "Kereta Cepat Jakarta Bandung"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Bandung on behalf of Dylangamin.
This should fix #928

> @railmapgen/rmg-palette-resources@2.1.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Jakarta Bandung High Speed: bg=`#404040`, fg=`#fff`