### PR TITLE
Resources: New palettes of Dubai

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -357,6 +357,16 @@
         }
     },
     {
+        "id": "dubai",
+        "country": "UAE",
+        "name": {
+            "en": "Dubai",
+            "zh-Hans": "迪拜",
+            "zh-Hant": "杜拜",
+            "ar": "دبي"
+        }
+    },
+    {
         "id": "dublin",
         "country": "IE",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -475,6 +475,16 @@
         "language": "uk"
     },
     {
+        "id": "UAE",
+        "name": {
+            "en": "United Arab Emirates",
+            "zh-Hans": "阿拉伯联合酋长国",
+            "zh-Hant": "阿拉伯聯合酋長國",
+            "ar": "الإمارات العربية المتحدة"
+        },
+        "language": "ar"
+    },
+    {
         "id": "UN",
         "name": {
             "en": "Customise",

--- a/public/resources/palettes/dubai.json
+++ b/public/resources/palettes/dubai.json
@@ -1,0 +1,35 @@
+[
+    {
+        "id": "dbred",
+        "colour": "#e4061f",
+        "fg": "#fff",
+        "name": {
+            "en": "Red Line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅線",
+            "ar": "الخط الأحمر"
+        }
+    },
+    {
+        "id": "dbgreen",
+        "colour": "#00a243",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠線",
+            "ar": "الخط الأخضر"
+        }
+    },
+    {
+        "id": "dbtram",
+        "colour": "#ec6906",
+        "fg": "#fff",
+        "name": {
+            "en": "Tram Line",
+            "zh-Hans": "迪拜电车",
+            "zh-Hant": "杜拜電車",
+            "ar": "ترام دبي"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Dubai on behalf of 28yfang.
This should fix #935

> @railmapgen/rmg-palette-resources@2.1.3 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Red Line: bg=`#e4061f`, fg=`#fff`
Green Line: bg=`#00a243`, fg=`#fff`
Tram Line: bg=`#ec6906`, fg=`#fff`