### PR TITLE
Resources: New palettes of Gwangju

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -485,6 +485,16 @@
         }
     },
     {
+        "id": "gwangju",
+        "country": "KR",
+        "name": {
+            "en": "Gwangju",
+            "ko": "광주",
+            "zh-Hans": "光州",
+            "zh-Hant": "光州"
+        }
+    },
+    {
         "id": "hamburg",
         "country": "DE",
         "name": {

--- a/public/resources/palettes/gwangju.json
+++ b/public/resources/palettes/gwangju.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": "g1",
+        "colour": "#009088",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線",
+            "ko": "1호선"
+        }
+    },
+    {
+        "id": "g2",
+        "colour": "#0471c3",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線",
+            "ko": "2호선"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Gwangju on behalf of Hzr061534.
This should fix #944

> @railmapgen/rmg-palette-resources@2.1.4 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#009088`, fg=`#fff`
Line 2: bg=`#0471c3`, fg=`#fff`