### PR TITLE
Resources: New palettes of Daejeon(Chungcheong Province)

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -319,6 +319,16 @@
         }
     },
     {
+        "id": "daejeon",
+        "country": "KR",
+        "name": {
+            "en": "Daejeon(Chungcheong Province)",
+            "zh-Hans": "大田（忠清道）",
+            "zh-Hant": "大田（忠清道）",
+            "ko": "대전（충청도)"
+        }
+    },
+    {
         "id": "dalian",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/daejeon.json
+++ b/public/resources/palettes/daejeon.json
@@ -1,0 +1,35 @@
+[
+    {
+        "id": "dj1",
+        "colour": "#007448",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線",
+            "ko": "1호선"
+        }
+    },
+    {
+        "id": "dj2",
+        "colour": "#5fc0b9",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線",
+            "ko": "2호선"
+        }
+    },
+    {
+        "id": "djcmr",
+        "colour": "#0054a6",
+        "fg": "#fff",
+        "name": {
+            "en": "Chungcheong Metropolitan Railroad",
+            "zh-Hans": "忠清圈 广域铁道",
+            "zh-Hant": "忠清圈 廣域鐵道",
+            "ko": "충청권 광역철도"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Daejeon(Chungcheong Province) on behalf of Hzr061534.
This should fix #946

> @railmapgen/rmg-palette-resources@2.1.4 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#007448`, fg=`#fff`
Line 2: bg=`#5fc0b9`, fg=`#fff`
Chungcheong Metropolitan Railroad: bg=`#0054a6`, fg=`#fff`