### PR TITLE
Resources: New palettes of Jinan

### DIFF
--- a/public/resources/palettes/jinan.json
+++ b/public/resources/palettes/jinan.json
@@ -1,38 +1,52 @@
 [
     {
         "id": "jn1",
+        "colour": "#BE1FA1",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#BE1FA1"
+        }
     },
     {
         "id": "jn2",
+        "colour": "#FFB620",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#FFB620"
+        }
     },
     {
         "id": "jn3",
+        "colour": "#00579e",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#0073CE"
+        }
     },
     {
         "id": "jn4",
+        "colour": "#229719",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#229719"
+        }
+    },
+    {
+        "id": "jn6",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Jinan on behalf of 4237155.
This should fix #948

> @railmapgen/rmg-palette-resources@2.1.4 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#BE1FA1`, fg=`#fff`
Line 2: bg=`#FFB620`, fg=`#fff`
Line 3: bg=`#00579e`, fg=`#fff`
Line 4: bg=`#229719`, fg=`#fff`
Line 6: bg=`#ff0000`, fg=`#fff`