### PR TITLE
Resources: New palettes of Kyoto

### DIFF
--- a/public/resources/palettes/kyoto.json
+++ b/public/resources/palettes/kyoto.json
@@ -16,8 +16,8 @@
         "fg": "#fff",
         "name": {
             "en": "Karasuma Line",
-            "zh-Hans": "鸟丸线",
-            "zh-Hant": "鳥丸綫",
+            "zh-Hans": "乌丸线",
+            "zh-Hant": "烏丸綫",
             "ja": "烏丸線"
         }
     }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Kyoto on behalf of WanyunMediaGroup.
This should fix #952

> @railmapgen/rmg-palette-resources@2.1.5 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Tozai Line: bg=`#ff4500`, fg=`#fff`
Karasuma Line: bg=`#3cb371`, fg=`#fff`