### PR TITLE
Resources: New palettes of Beijing

### DIFF
--- a/public/resources/palettes/beijing.json
+++ b/public/resources/palettes/beijing.json
@@ -62,7 +62,7 @@
     {
         "id": "bj7",
         "colour": "#f6c582",
-        "fg": "#000",
+        "fg": "#fff",
         "name": {
             "en": "Line 7",
             "zh-Hans": "7号线",
@@ -120,13 +120,23 @@
         }
     },
     {
-        "id": "bj13",
+        "id": "bj13A",
         "colour": "#f9e700",
-        "fg": "#000",
+        "fg": "#fff",
         "name": {
-            "en": "Line 13",
-            "zh-Hans": "13号线",
-            "zh-Hant": "13號線"
+            "en": "Line 13A",
+            "zh-Hans": "13A线",
+            "zh-Hant": "13A線"
+        }
+    },
+    {
+        "id": "bj13B",
+        "colour": "#e8bb71",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 13B",
+            "zh-Hans": "13B线",
+            "zh-Hant": "13B線"
         }
     },
     {
@@ -182,7 +192,7 @@
     {
         "id": "bj22",
         "colour": "#f4c1ca",
-        "fg": "#000",
+        "fg": "#fff",
         "name": {
             "en": "Line 22 (Pinggu Line)",
             "zh-Hans": "22号线（平谷线）",
@@ -212,7 +222,7 @@
     {
         "id": "bj27cp",
         "colour": "#de82b2",
-        "fg": "#000",
+        "fg": "#fff",
         "name": {
             "en": "Changping Line",
             "zh-Hans": "昌平线",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Beijing on behalf of XJYCL.
This should fix #956

> @railmapgen/rmg-palette-resources@2.1.5 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1/Batong Line: bg=`#c23a30`, fg=`#fff`
Line 2: bg=`#006098`, fg=`#fff`
Line 3: bg=`#d90627`, fg=`#fff`
Line 4/Daxing Line: bg=`#008e9c`, fg=`#fff`
Line 5: bg=`#a6217f`, fg=`#fff`
Line 6: bg=`#d29700`, fg=`#fff`
Line 7: bg=`#f6c582`, fg=`#fff`
Line 8: bg=`#009b6b`, fg=`#fff`
Line 9: bg=`#8fc31f`, fg=`#000`
Line 10: bg=`#009bc0`, fg=`#fff`
Line 11: bg=`#ED796B`, fg=`#fff`
Line 12: bg=`#9c4f01`, fg=`#fff`
Line 13A: bg=`#f9e700`, fg=`#fff`
Line 13B: bg=`#e8bb71`, fg=`#fff`
Line 14: bg=`#d5a7a1`, fg=`#000`
Line 15: bg=`#5b2c68`, fg=`#fff`
Line 16: bg=`#76a32e`, fg=`#fff`
Line 17: bg=`#00A9A9`, fg=`#fff`
Line 19: bg=`#D6ABC1`, fg=`#000`
Line 22 (Pinggu Line): bg=`#f4c1ca`, fg=`#fff`
Line 28: bg=`#476205`, fg=`#fff`
Fangshan Line/Yanfang Line: bg=`#e46022`, fg=`#fff`
Changping Line: bg=`#de82b2`, fg=`#fff`
Yizhuang Line: bg=`#e40077`, fg=`#fff`
Line S1: bg=`#b35a20`, fg=`#fff`
Capital Airport Express: bg=`#a29bbb`, fg=`#000`
Daxing Airport Express: bg=`#004a9f`, fg=`#fff`
Xijiao Line: bg=`#e50619`, fg=`#fff`
Yizhuang T1 Line: bg=`#e5061b`, fg=`#fff`