### PR TITLE
Resources: New palettes of Bangalore

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -59,6 +59,15 @@
         }
     },
     {
+        "id": "bangalore",
+        "country": "IN",
+        "name": {
+            "en": "Bangalore",
+            "zh-Hans": "班加罗尔",
+            "zh-Hant": "班加羅爾"
+        }
+    },
+    {
         "id": "bangkok",
         "country": "TH",
         "name": {

--- a/public/resources/palettes/bangalore.json
+++ b/public/resources/palettes/bangalore.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "bg",
+        "colour": "#58ba49",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "緑缐"
+        }
+    },
+    {
+        "id": "bp",
+        "colour": "#a952a0",
+        "fg": "#fff",
+        "name": {
+            "en": "Purple Line",
+            "zh-Hans": "紫线",
+            "zh-Hant": "紫缐"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Bangalore on behalf of linchen1965.
This should fix #958

> @railmapgen/rmg-palette-resources@2.1.5 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Green Line: bg=`#58ba49`, fg=`#fff`
Purple Line: bg=`#a952a0`, fg=`#fff`