### PR TITLE
Resources: New palettes of Hezhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -552,6 +552,14 @@
         }
     },
     {
+        "id": "hezhou",
+        "country": "CN",
+        "name": {
+            "en": "Hezhou",
+            "zh-Hans": "贺州"
+        }
+    },
+    {
         "id": "hiroshima",
         "country": "JP",
         "name": {

--- a/public/resources/palettes/hezhou.json
+++ b/public/resources/palettes/hezhou.json
@@ -1,0 +1,20 @@
+[
+    {
+        "id": "hz1",
+        "colour": "#4d9f68",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线"
+        }
+    },
+    {
+        "id": "hz2",
+        "colour": "#f8d84c",
+        "fg": "#000",
+        "name": {
+            "en": "Line 2",
+            "zh-Hans": "2号线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Hezhou on behalf of KimJisso0610.
This should fix #963

> @railmapgen/rmg-palette-resources@2.1.5 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#4d9f68`, fg=`#fff`
Line 2: bg=`#f8d84c`, fg=`#000`