### PR TITLE
Resources: New palettes of Taizhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1491,6 +1491,15 @@
         }
     },
     {
+        "id": "taizhou",
+        "country": "CN",
+        "name": {
+            "en": "Taizhou",
+            "zh-Hans": "台州",
+            "zh-Hant": "臺州"
+        }
+    },
+    {
         "id": "taoyuan",
         "country": "TW",
         "name": {

--- a/public/resources/palettes/taizhou.json
+++ b/public/resources/palettes/taizhou.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "ta S1",
+        "colour": "#6363f2",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh-Hans": "S1线",
+            "zh-Hant": "S1線"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Taizhou on behalf of Xiao-qian111.
This should fix #967

> @railmapgen/rmg-palette-resources@2.1.5 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line S1: bg=`#6363f2`, fg=`#fff`