### PR TITLE
Resources: New palettes of Fuzhou

### DIFF
--- a/public/resources/palettes/fuzhou.json
+++ b/public/resources/palettes/fuzhou.json
@@ -64,5 +64,35 @@
             "zh-Hans": "滨海快线",
             "zh-Hant": "濱海快缐"
         }
+    },
+    {
+        "id": "fzs1",
+        "colour": "#b57763",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh-Hans": "S1号线",
+            "zh-Hant": "S1號線"
+        }
+    },
+    {
+        "id": "fz8",
+        "colour": "#adcb14",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號線"
+        }
+    },
+    {
+        "id": "fz3",
+        "colour": "#ff3f7b",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Fuzhou on behalf of Chang87.
This should fix #972

> @railmapgen/rmg-palette-resources@2.1.5 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#bb1e10`, fg=`#fff`
Line 2: bg=`#325928`, fg=`#fff`
Line 4: bg=`#ff7f41`, fg=`#fff`
Line 5: bg=`#893b67`, fg=`#fff`
Line 6: bg=`#005eb8`, fg=`#fff`
Binhai Express: bg=`#00adbb`, fg=`#fff`
Line S1: bg=`#b57763`, fg=`#fff`
Line 8: bg=`#adcb14`, fg=`#fff`
Line 3: bg=`#ff3f7b`, fg=`#fff`