### PR TITLE
Resources: New palettes of Wenzhou

### DIFF
--- a/public/resources/palettes/wenzhou.json
+++ b/public/resources/palettes/wenzhou.json
@@ -20,5 +20,15 @@
             "zh-Hans": "S2线",
             "zh-Hant": "S2線"
         }
+    },
+    {
+        "id": "wzs3",
+        "colour": "#ff9900",
+        "fg": "#fff",
+        "name": {
+            "en": "LineS3",
+            "zh-Hans": "S3线",
+            "zh-Hant": "S3線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wenzhou on behalf of AndreaFrederica.
This should fix #975

> @railmapgen/rmg-palette-resources@2.1.5 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line S1: bg=`#0061ae`, fg=`#fff`
Line S2: bg=`#e4002b`, fg=`#fff`
LineS3: bg=`#ff9900`, fg=`#fff`