### PR TITLE
Resources: New palettes of Charleroi

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -243,6 +243,16 @@
         }
     },
     {
+        "id": "charleroi",
+        "country": "BE",
+        "name": {
+            "en": "Charleroi",
+            "zh-Hans": "沙勒罗瓦",
+            "zh-Hant": "沙勒羅瓦",
+            "fr": "Charleroi"
+        }
+    },
+    {
         "id": "chengdu",
         "country": "CN",
         "name": {

--- a/public/resources/palettes/charleroi.json
+++ b/public/resources/palettes/charleroi.json
@@ -1,0 +1,112 @@
+[
+    {
+        "id": "cm1",
+        "colour": "#e51836",
+        "fg": "#fff",
+        "name": {
+            "en": "M1",
+            "zh-Hans": "M1",
+            "zh-Hant": "M1",
+            "fr": "M1"
+        }
+    },
+    {
+        "id": "cm2",
+        "colour": "#8fc63e",
+        "fg": "#fff",
+        "name": {
+            "en": "M2",
+            "zh-Hans": "M2",
+            "zh-Hant": "M2",
+            "fr": "M2"
+        }
+    },
+    {
+        "id": "cm3",
+        "colour": "#faa91e",
+        "fg": "#fff",
+        "name": {
+            "en": "M3",
+            "zh-Hans": "M3",
+            "zh-Hant": "M3",
+            "fr": "M3"
+        }
+    },
+    {
+        "id": "cm4",
+        "colour": "#00aeef",
+        "fg": "#fff",
+        "name": {
+            "en": "M4",
+            "zh-Hans": "M4",
+            "zh-Hant": "M4",
+            "fr": "M4"
+        }
+    },
+    {
+        "id": "cm5",
+        "colour": "#d33595",
+        "fg": "#fff",
+        "name": {
+            "en": "M5",
+            "zh-Hans": "M5",
+            "zh-Hant": "M5",
+            "fr": "M5"
+        }
+    },
+    {
+        "id": "cs19",
+        "colour": "#f16daa",
+        "fg": "#fff",
+        "name": {
+            "en": "S19",
+            "zh-Hans": "S19",
+            "zh-Hant": "S19",
+            "fr": "S19"
+        }
+    },
+    {
+        "id": "cs61",
+        "colour": "#035e33",
+        "fg": "#fff",
+        "name": {
+            "en": "S61",
+            "zh-Hans": "S61",
+            "zh-Hant": "S61",
+            "fr": "S61"
+        }
+    },
+    {
+        "id": "cs62",
+        "colour": "#f26021",
+        "fg": "#fff",
+        "name": {
+            "en": "S62",
+            "zh-Hans": "S62",
+            "zh-Hant": "S62",
+            "fr": "S62"
+        }
+    },
+    {
+        "id": "cs63",
+        "colour": "#202776",
+        "fg": "#fff",
+        "name": {
+            "en": "S63",
+            "zh-Hans": "S63",
+            "zh-Hant": "S63",
+            "fr": "S63"
+        }
+    },
+    {
+        "id": "cs64",
+        "colour": "#cc2027",
+        "fg": "#fff",
+        "name": {
+            "en": "S64",
+            "zh-Hans": "S64",
+            "zh-Hant": "S64",
+            "fr": "S64"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Charleroi on behalf of linchen1965.
This should fix #989

> @railmapgen/rmg-palette-resources@2.1.6 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

M1: bg=`#e51836`, fg=`#fff`
M2: bg=`#8fc63e`, fg=`#fff`
M3: bg=`#faa91e`, fg=`#fff`
M4: bg=`#00aeef`, fg=`#fff`
M5: bg=`#d33595`, fg=`#fff`
S19: bg=`#f16daa`, fg=`#fff`
S61: bg=`#035e33`, fg=`#fff`
S62: bg=`#f26021`, fg=`#fff`
S63: bg=`#202776`, fg=`#fff`
S64: bg=`#cc2027`, fg=`#fff`