### PR TITLE
Resources: New palettes of Wuhan

### DIFF
--- a/public/resources/palettes/wuhan.json
+++ b/public/resources/palettes/wuhan.json
@@ -150,6 +150,16 @@
         }
     },
     {
+        "id": "wh19",
+        "colour": "#18a079",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 19",
+            "zh-Hans": "19号线",
+            "zh-Hant": "19號線"
+        }
+    },
+    {
         "id": "wh21",
         "colour": "#CF0192",
         "fg": "#fff",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wuhan on behalf of Bachongshenzi1453.
This should fix #995

> @railmapgen/rmg-palette-resources@2.1.7 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#3D84C6`, fg=`#fff`
Line 2: bg=`#EB7CAF`, fg=`#fff`
Line 3: bg=`#D9B966`, fg=`#fff`
Line 4: bg=`#8EC720`, fg=`#fff`
Line 5: bg=`#a62e37`, fg=`#fff`
Line 6: bg=`#008536`, fg=`#fff`
Line 7: bg=`#EB7900`, fg=`#fff`
Line 8: bg=`#98ACAB`, fg=`#fff`
Line 9: bg=`#A5D4AD`, fg=`#fff`
Line 10: bg=`#8C3626`, fg=`#fff`
Line 11: bg=`#F2CF01`, fg=`#fff`
Line 12: bg=`#00A3E9`, fg=`#fff`
Line 13: bg=`#25CAD0`, fg=`#fff`
Line 14: bg=`#7D55A3`, fg=`#fff`
Line 16: bg=`#CC0256`, fg=`#fff`
Line 19: bg=`#18a079`, fg=`#fff`
Line 21: bg=`#CF0192`, fg=`#fff`
Suspended Monorail Line: bg=`#05aff1`, fg=`#fff`
Wuhan Optics Valley Modern Tram Line 1: bg=`#0000ff`, fg=`#fff`
Wuhan Optics Valley Modern Tram Line 2: bg=`#ff0000`, fg=`#fff`
Wuhan Optics Valley Modern Tram Line 5 (Event Time Only): bg=`#818181`, fg=`#fff`