### PR TITLE
Resources: New palettes of Paris

### DIFF
--- a/public/resources/palettes/paris.json
+++ b/public/resources/palettes/paris.json
@@ -371,6 +371,17 @@
         }
     },
     {
+        "id": "t12",
+        "colour": "#b6134c",
+        "fg": "#fff",
+        "name": {
+            "en": "Tramway Line 12",
+            "fr": "Tramway Ligne 12",
+            "zh-Hans": "有轨电车T12号线",
+            "zh-Hant": "有軌電車T12號線"
+        }
+    },
+    {
         "id": "t13",
         "colour": "#6e491e",
         "fg": "#fff",
@@ -618,6 +629,7 @@
         "colour": "#e3051b",
         "fg": "#fff",
         "name": {
+            "fr": "OrlyBus/RoissyBus",
             "en": "OrlyBus/RoissyBus"
         }
     }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Paris on behalf of lcs27.
This should fix #1001

> @railmapgen/rmg-palette-resources@2.1.7 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Metro Line 1: bg=`#FFCE00`, fg=`#000`
Metro Line 2: bg=`#0064B0`, fg=`#fff`
Metro Line 3: bg=`#9F9825`, fg=`#fff`
Metro Line 3b: bg=`#98D4E2`, fg=`#000`
Metro Line 4: bg=`#C04191`, fg=`#fff`
Metro Line 5: bg=`#F28E42`, fg=`#000`
Metro Line 6: bg=`#83C491`, fg=`#000`
Metro Line 7: bg=`#F3A4BA`, fg=`#000`
Metro Line 7b: bg=`#84c28e`, fg=`#000`
Metro Line 8: bg=`#CEADD2`, fg=`#000`
Metro Line 9: bg=`#D5C900`, fg=`#000`
Metro Line 10: bg=`#E3B32A`, fg=`#000`
Metro Line 11: bg=`#8D5E2A`, fg=`#fff`
Metro Line 12: bg=`#00814F`, fg=`#fff`
Metro Line 13: bg=`#98D4E2`, fg=`#000`
Metro Line 14: bg=`#662483`, fg=`#fff`
OrlyVal: bg=`#FFCD0D`, fg=`#fff`
RER Line A: bg=`#E3051C`, fg=`#fff`
RER Line B: bg=`#5291CE`, fg=`#fff`
RER Line C: bg=`#F6D200`, fg=`#000`
RER Line D: bg=`#009E59`, fg=`#fff`
RER Line E: bg=`#D682B5`, fg=`#fff`
Tramway Line 1: bg=`#0064B0`, fg=`#fff`
Tramway Line 2: bg=`#C04191`, fg=`#fff`
Tramway Line 3a: bg=`#F28E42`, fg=`#fff`
Tramway Line 3b: bg=`#009E59`, fg=`#fff`
Tramway Line 4: bg=`#FAB31E`, fg=`#fff`
Tramway Line 5: bg=`#662483`, fg=`#fff`
Tramway Line 6: bg=`#E3051C`, fg=`#fff`
Tramway Line 7: bg=`#8D5E2A`, fg=`#fff`
Tramway Line 8: bg=`#9F9825`, fg=`#fff`
Tramway Line 9: bg=`#4F8FCC`, fg=`#fff`
Tramway Line 10: bg=`#706c01`, fg=`#fff`
Tramway Line 11: bg=`#E2562C`, fg=`#fff`
Tramway Line 12: bg=`#b6134c`, fg=`#fff`
Tramway Line 13: bg=`#6e491e`, fg=`#fff`
Transilien Line H: bg=`#8c602b`, fg=`#fff`
Transilien Line J: bg=`#d2ce00`, fg=`#000`
Transilien Line K: bg=`#9d9b22`, fg=`#fff`
Transilien Line L: bg=`#ceaacf`, fg=`#000`
Transilien Line N: bg=`#00aa8f`, fg=`#fff`
Transilien Line P: bg=`#f2933d`, fg=`#000`
Transilien Line R: bg=`#f2a4b7`, fg=`#000`
Transilien Line U: bg=`#be0045`, fg=`#fff`
Bus 20/26/27/70/82/N24/N33/N43: bg=`#ea894d`, fg=`#000`
Bus 21/35/64/93/215/N21/N44/N53: bg=`#72be8d`, fg=`#000`
Bus 22/58/61/66: bg=`#008054`, fg=`#fff`
Bus 24/39/56/94: bg=`#ab458a`, fg=`#fff`
Bus 25/43/60/72/86/N66/N130/N150/N152/N153: bg=`#d82230`, fg=`#fff`
Bus 28/45/47/67/80/N31/N41/N62: bg=`#ec97a7`, fg=`#000`
Bus 29/40/52/54/69/89/325: bg=`#87ced0`, fg=`#000`
Bus 30/76/87/95/359: bg=`#572a79`, fg=`#fff`
Bus 31/42/68/75/83/92/N22/N35/N45/N51/N54/N131/N133: bg=`#f9c721`, fg=`#000`
Bus 32/57: bg=`#8e903b`, fg=`#fff`
Bus 38/48/77/PC: bg=`#0063a2`, fg=`#fff`
Bus 46/63/74/88/N34/N52/N63/N151: bg=`#c7c332`, fg=`#000`
Bus 59/91/96/N23/N32/N42/N61: bg=`#d5aa41`, fg=`#000`
Bus 62/71/73/85/201: bg=`#7f5d38`, fg=`#fff`
Bus 84: bg=`#bc9bbd`, fg=`#000`
Bus 528: bg=`#ea9080`, fg=`#000`
Bus N122/N140/N143: bg=`#4d86b8`, fg=`#fff`
Bus N132/N133/N144/N145: bg=`#00995a`, fg=`#fff`
Bus N141: bg=`#f1ac71`, fg=`#000`
Bus N142: bg=`#8d6a8f`, fg=`#fff`
OrlyBus/RoissyBus: bg=`#e3051b`, fg=`#fff`