### PR TITLE
Resources: New palettes of Shenzhen

### DIFF
--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -54,9 +54,9 @@
         "colour": "#00C7B1",
         "fg": "#fff",
         "name": {
-            "en": "Line 6",
-            "zh-Hans": "6号线",
-            "zh-Hant": "6號線"
+            "en": "Line 6（Guangming Line)",
+            "zh-Hans": "6号线（光明线）",
+            "zh-Hant": "6號線（光明線）"
         }
     },
     {
@@ -74,9 +74,9 @@
         "colour": "#0033A0",
         "fg": "#fff",
         "name": {
-            "en": "Line 7",
-            "zh-Hans": "7号线",
-            "zh-Hant": "7號線"
+            "en": "Line 7(Xili Line)",
+            "zh-Hans": "7号线（西丽线）",
+            "zh-Hant": "7號線（西麗線）"
         }
     },
     {
@@ -94,9 +94,9 @@
         "colour": "#7B6469",
         "fg": "#fff",
         "name": {
-            "en": "Line 9",
-            "zh-Hans": "9号线",
-            "zh-Hant": "9號線"
+            "en": "Line 9(Meilin Line)",
+            "zh-Hans": "9号线（梅林线）",
+            "zh-Hant": "9號線（梅林線）"
         }
     },
     {
@@ -104,9 +104,9 @@
         "colour": "#F8779E",
         "fg": "#fff",
         "name": {
-            "en": "Line 10",
-            "zh-Hans": "10号线",
-            "zh-Hant": "10號線"
+            "en": "Line 10(Bantian Line)",
+            "zh-Hans": "10号线（坂田线）",
+            "zh-Hant": "10號線（坂田線）"
         }
     },
     {
@@ -124,9 +124,9 @@
         "colour": "#A192B2",
         "fg": "#fff",
         "name": {
-            "en": "Line 12",
-            "zh-Hans": "12号线",
-            "zh-Hant": "12號線"
+            "en": "Line 12(Nanbao Line)",
+            "zh-Hans": "12号线（南宝线）",
+            "zh-Hant": "12號線（南寶線）"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenzhen on behalf of GuanyuChan.
This should fix #1010

> @railmapgen/rmg-palette-resources@2.1.8 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1 (Luobao Line): bg=`#00B140`, fg=`#fff`
Line 2 (Shekou Line): bg=`#B94700`, fg=`#fff`
Line 3 (Longgang Line): bg=`#00A9E0`, fg=`#fff`
Line 4 (Longhua Line): bg=`#DA291C`, fg=`#fff`
Line 5 (Huanzhong Line): bg=`#A05EB5`, fg=`#fff`
Line 6（Guangming Line): bg=`#00C7B1`, fg=`#fff`
Line 6 branch: bg=`#168773`, fg=`#fff`
Line 7(Xili Line): bg=`#0033A0`, fg=`#fff`
Line 8: bg=`#b94700`, fg=`#fff`
Line 9(Meilin Line): bg=`#7B6469`, fg=`#fff`
Line 10(Bantian Line): bg=`#F8779E`, fg=`#fff`
Line 11: bg=`#672146`, fg=`#fff`
Line 12(Nanbao Line): bg=`#A192B2`, fg=`#fff`
Line 13: bg=`#DE7C00`, fg=`#fff`
Line 14: bg=`#F2C75C`, fg=`#fff`
Line 15: bg=`#84BD00`, fg=`#fff`
Line 16: bg=`#1E22AA`, fg=`#fff`
Line 20: bg=`#88DBDF`, fg=`#fff`
Tram: bg=`#b8b8b8`, fg=`#fff`
Line 8 (Original): bg=`#E45DBF`, fg=`#fff`
Pingshan sky shuttlo: bg=`#1974d2`, fg=`#fff`