### PR TITLE
Resources: New palettes of Taizhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1519,6 +1519,15 @@
         }
     },
     {
+        "id": "taizhou",
+        "country": "CN",
+        "name": {
+            "en": "Taizhou",
+            "zh-Hans": "台州",
+            "zh-Hant": "台州"
+        }
+    },
+    {
         "id": "taoyuan",
         "country": "TW",
         "name": {

--- a/public/resources/palettes/taizhou.json
+++ b/public/resources/palettes/taizhou.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "tz1",
+        "colour": "#1194d4",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "1号线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Taizhou on behalf of microharddemo.
This should fix #1023

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#1194d4`, fg=`#fff`