### PR TITLE
Resources: New palettes of Guangzhou

### DIFF
--- a/public/resources/palettes/guangzhou.json
+++ b/public/resources/palettes/guangzhou.json
@@ -293,7 +293,7 @@
     },
     {
         "id": "thp2",
-        "colour": "#f25601",
+        "colour": "#e82583",
         "fg": "#fff",
         "name": {
             "en": "THP2",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Guangzhou on behalf of Zhenyu1302.
This should fix #1025

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#e7c148`, fg=`#000`
Line 2: bg=`#385f87`, fg=`#fff`
Line 3: bg=`#e4904c`, fg=`#fff`
Line 4: bg=`#35753b`, fg=`#fff`
Line 5: bg=`#bc3342`, fg=`#fff`
Line 6: bg=`#6d2f48`, fg=`#fff`
Line 7: bg=`#8cbd3a`, fg=`#fff`
Line 8: bg=`#3a7b79`, fg=`#fff`
Line 9: bg=`#73ba89`, fg=`#000`
Line 10: bg=`#7D9CC0`, fg=`#fff`
Line 11: bg=`#470A68`, fg=`#fff`
Line 12: bg=`#59621D`, fg=`#fff`
Line 13: bg=`#827c35`, fg=`#fff`
Line 14: bg=`#622b23`, fg=`#fff`
Line 15: bg=`#AE8A79`, fg=`#fff`
Line 16: bg=`#9E652E`, fg=`#fff`
Line 17: bg=`#8B84D7`, fg=`#fff`
Line 18: bg=`#494788`, fg=`#fff`
Line 19: bg=`#BB29BB`, fg=`#fff`
Line 20: bg=`#D60078`, fg=`#fff`
Line 21: bg=`#2c212e`, fg=`#fff`
Line 22: bg=`#c84c2e`, fg=`#fff`
Line 24: bg=`#1fada9`, fg=`#fff`
APM Line: bg=`#43b6cf`, fg=`#fff`
Guangfo Line: bg=`#b2cd34`, fg=`#000`
THZ1: bg=`#6cb23d`, fg=`#fff`
THP1: bg=`#ac2c26`, fg=`#fff`
THP2: bg=`#e82583`, fg=`#fff`
Foshan Metro: bg=`#565656`, fg=`#fff`