### PR TITLE
Resources: New palettes of Guiyang

### DIFF
--- a/public/resources/palettes/guiyang.json
+++ b/public/resources/palettes/guiyang.json
@@ -20,5 +20,16 @@
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
         }
+    },
+    {
+        "id": "gy3",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "ko": "3호선",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Guiyang on behalf of oumija.
This should fix #1031

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#259b24`, fg=`#fff`
Line 2: bg=`#005bac`, fg=`#fff`
Line 3: bg=`#ff0000`, fg=`#fff`