### PR TITLE
Resources: New palettes of Taizhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1519,6 +1519,17 @@
         }
     },
     {
+        "id": "taizhou",
+        "country": "CN",
+        "name": {
+            "en": "Taizhou",
+            "zh-Hans": "台州",
+            "zh-Hant": "台州",
+            "ja": "台州",
+            "ko": "타이저우"
+        }
+    },
+    {
         "id": "taoyuan",
         "country": "TW",
         "name": {

--- a/public/resources/palettes/taizhou.json
+++ b/public/resources/palettes/taizhou.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": "tzs1",
+        "colour": "#2392e7",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh-Hans": "S1线",
+            "zh-Hant": "S1線",
+            "ja": "S1線",
+            "ko": "S1선"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Taizhou on behalf of Wuyirende.
This should fix #1033

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line S1: bg=`#2392e7`, fg=`#fff`