### PR TITLE
Resources: New palettes of Shenzhen

### DIFF
--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -134,9 +134,9 @@
         "colour": "#DE7C00",
         "fg": "#fff",
         "name": {
-            "en": "Line 13",
-            "zh-Hans": "13号线",
-            "zh-Hant": "13號線"
+            "en": "Line 13(Shiyan Line)",
+            "zh-Hans": "13号线（石岩线）",
+            "zh-Hant": "13號線（石岩線）"
         }
     },
     {
@@ -144,9 +144,9 @@
         "colour": "#F2C75C",
         "fg": "#fff",
         "name": {
-            "en": "Line 14",
-            "zh-Hans": "14号线",
-            "zh-Hant": "14號線"
+            "en": "Line 14(Eastern Express)",
+            "zh-Hans": "14号线（东部快线）",
+            "zh-Hant": "14號線（東部快線）"
         }
     },
     {
@@ -164,9 +164,9 @@
         "colour": "#1E22AA",
         "fg": "#fff",
         "name": {
-            "en": "Line 16",
-            "zh-Hans": "16号线",
-            "zh-Hant": "16號線"
+            "en": "Line 16(Longping Line)",
+            "zh-Hans": "16号线（龙坪线）",
+            "zh-Hant": "16號線（龍坪線）"
         }
     },
     {

--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -74,7 +74,7 @@
         "colour": "#0033A0",
         "fg": "#fff",
         "name": {
-            "en": "Line 7(Xili Line)",
+            "en": "Line 7 (Xili Line)",
             "zh-Hans": "7号线（西丽线）",
             "zh-Hant": "7號線（西麗線）"
         }
@@ -94,7 +94,7 @@
         "colour": "#7B6469",
         "fg": "#fff",
         "name": {
-            "en": "Line 9(Meilin Line)",
+            "en": "Line 9 (Meilin Line)",
             "zh-Hans": "9号线（梅林线）",
             "zh-Hant": "9號線（梅林線）"
         }
@@ -104,7 +104,7 @@
         "colour": "#F8779E",
         "fg": "#fff",
         "name": {
-            "en": "Line 10(Bantian Line)",
+            "en": "Line 10 (Bantian Line)",
             "zh-Hans": "10号线（坂田线）",
             "zh-Hant": "10號線（坂田線）"
         }
@@ -124,7 +124,7 @@
         "colour": "#A192B2",
         "fg": "#fff",
         "name": {
-            "en": "Line 12(Nanbao Line)",
+            "en": "Line 12 (Nanbao Line)",
             "zh-Hans": "12号线（南宝线）",
             "zh-Hant": "12號線（南寶線）"
         }
@@ -134,7 +134,7 @@
         "colour": "#DE7C00",
         "fg": "#fff",
         "name": {
-            "en": "Line 13(Shiyan Line)",
+            "en": "Line 13 (Shiyan Line)",
             "zh-Hans": "13号线（石岩线）",
             "zh-Hant": "13號線（石岩線）"
         }
@@ -144,7 +144,7 @@
         "colour": "#F2C75C",
         "fg": "#fff",
         "name": {
-            "en": "Line 14(Eastern Express)",
+            "en": "Line 14 (Eastern Express)",
             "zh-Hans": "14号线（东部快线）",
             "zh-Hant": "14號線（東部快線）"
         }
@@ -164,7 +164,7 @@
         "colour": "#1E22AA",
         "fg": "#fff",
         "name": {
-            "en": "Line 16(Longping Line)",
+            "en": "Line 16 (Longping Line)",
             "zh-Hans": "16号线（龙坪线）",
             "zh-Hant": "16號線（龍坪線）"
         }


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenzhen on behalf of GuanyuChan.
This should fix #1035

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1 (Luobao Line): bg=`#00B140`, fg=`#fff`
Line 2 (Shekou Line): bg=`#B94700`, fg=`#fff`
Line 3 (Longgang Line): bg=`#00A9E0`, fg=`#fff`
Line 4 (Longhua Line): bg=`#DA291C`, fg=`#fff`
Line 5 (Huanzhong Line): bg=`#A05EB5`, fg=`#fff`
Line 6（Guangming Line): bg=`#00C7B1`, fg=`#fff`
Line 6 branch: bg=`#168773`, fg=`#fff`
Line 7(Xili Line): bg=`#0033A0`, fg=`#fff`
Line 8: bg=`#b94700`, fg=`#fff`
Line 9(Meilin Line): bg=`#7B6469`, fg=`#fff`
Line 10(Bantian Line): bg=`#F8779E`, fg=`#fff`
Line 11: bg=`#672146`, fg=`#fff`
Line 12(Nanbao Line): bg=`#A192B2`, fg=`#fff`
Line 13(Shiyan Line): bg=`#DE7C00`, fg=`#fff`
Line 14(Eastern Express): bg=`#F2C75C`, fg=`#fff`
Line 15: bg=`#84BD00`, fg=`#fff`
Line 16(Longping Line): bg=`#1E22AA`, fg=`#fff`
Line 20: bg=`#88DBDF`, fg=`#fff`
Tram: bg=`#b8b8b8`, fg=`#fff`
Line 8 (Original): bg=`#E45DBF`, fg=`#fff`
Pingshan sky shuttlo: bg=`#1974d2`, fg=`#fff`