### PR TITLE
Resources: New palettes of Liuzhou

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -832,6 +832,15 @@
         }
     },
     {
+        "id": "liuzhou",
+        "country": "CN",
+        "name": {
+            "en": "Liuzhou",
+            "zh-Hans": "柳州",
+            "zh-Hant": "柳州"
+        }
+    },
+    {
         "id": "london",
         "country": "GBENG",
         "name": {

--- a/public/resources/palettes/liuzhou.json
+++ b/public/resources/palettes/liuzhou.json
@@ -1,0 +1,52 @@
+[
+    {
+        "id": "lz1",
+        "colour": "#ff9900",
+        "fg": "#fff",
+        "name": {
+            "en": "line 1",
+            "zh-Hans": "一号线",
+            "zh-Hant": "一号线"
+        }
+    },
+    {
+        "id": "lz2",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "line 2",
+            "zh-Hans": "2号线",
+            "zh-Hant": "2号线"
+        }
+    },
+    {
+        "id": "lz3",
+        "colour": "#4a86e8",
+        "fg": "#fff",
+        "name": {
+            "en": "line 3",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3号线"
+        }
+    },
+    {
+        "id": "lz4",
+        "colour": "#44ff0d",
+        "fg": "#fff",
+        "name": {
+            "en": "line 4",
+            "zh-Hans": "4号线",
+            "zh-Hant": "4号线"
+        }
+    },
+    {
+        "id": "lz5",
+        "colour": "#9900ff",
+        "fg": "#fff",
+        "name": {
+            "en": "line 5",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5号线"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Liuzhou on behalf of liuzhou0925.
This should fix #1038

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

line 1: bg=`#ff9900`, fg=`#fff`
line 2: bg=`#ff0000`, fg=`#fff`
line 3: bg=`#4a86e8`, fg=`#fff`
line 4: bg=`#44ff0d`, fg=`#fff`
line 5: bg=`#9900ff`, fg=`#fff`