### PR TITLE
Resources: New palettes of Lima

### DIFF
--- a/public/resources/palettes/lima.json
+++ b/public/resources/palettes/lima.json
@@ -1,42 +1,68 @@
 [
     {
         "id": "lm1",
+        "colour": "#509e2f",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "es": "Línea 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#08AB5E"
+        }
     },
     {
         "id": "lm2",
+        "colour": "#ffb81c",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "es": "Línea 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#FFC82A"
+        }
     },
     {
         "id": "lm3",
+        "colour": "#00c1d5",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "es": "Línea 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#00ACEF"
+        }
     },
     {
         "id": "lm4",
+        "colour": "#da291c",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "es": "Línea 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#DD3539"
+        }
+    },
+    {
+        "id": "lm5",
+        "colour": "#f57eb6",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "es": "Línea 5",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號線"
+        }
+    },
+    {
+        "id": "lm6",
+        "colour": "#8b84d7",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "es": "Línea 6",
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Lima on behalf of linchen1965.
This should fix #1003

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#509e2f`, fg=`#fff`
Line 2: bg=`#ffb81c`, fg=`#fff`
Line 3: bg=`#00c1d5`, fg=`#fff`
Line 4: bg=`#da291c`, fg=`#fff`
Line 5: bg=`#f57eb6`, fg=`#fff`
Line 6: bg=`#8b84d7`, fg=`#fff`