### PR TITLE
Resources: New palettes of Guiyang

### DIFF
--- a/public/resources/palettes/guiyang.json
+++ b/public/resources/palettes/guiyang.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "gy1",
-        "colour": "#259b24",
+        "colour": "#7ab74b",
         "fg": "#fff",
         "name": {
             "en": "Line 1",
@@ -12,13 +12,35 @@
     },
     {
         "id": "gy2",
-        "colour": "#005bac",
+        "colour": "#121e59",
         "fg": "#fff",
         "name": {
             "en": "Line 2",
             "ko": "2호선",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
+        }
+    },
+    {
+        "id": "gy3",
+        "colour": "#ff0000",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 3",
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線",
+            "ko": "3호선"
+        }
+    },
+    {
+        "id": "gys1",
+        "colour": "#720160",
+        "fg": "#fff",
+        "name": {
+            "en": "Line S1",
+            "zh-Hans": "S1线",
+            "zh-Hant": "S1線",
+            "ko": "S1선"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Guiyang on behalf of Wuyirende.
This should fix #1046

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#7ab74b`, fg=`#fff`
Line 2: bg=`#121e59`, fg=`#fff`
Line 3: bg=`#ff0000`, fg=`#fff`
Line S1: bg=`#720160`, fg=`#fff`