### PR TITLE
Resources: New palettes of Changchun

### DIFF
--- a/public/resources/palettes/changchun.json
+++ b/public/resources/palettes/changchun.json
@@ -41,7 +41,7 @@
     },
     {
         "id": "cc5",
-        "colour": "#f8408a",
+        "colour": "#a88546",
         "fg": "#fff",
         "name": {
             "en": "Line 5",
@@ -51,7 +51,7 @@
     },
     {
         "id": "cc6",
-        "colour": "#df7413",
+        "colour": "#e48aa4",
         "fg": "#fff",
         "name": {
             "en": "Line 6",
@@ -61,7 +61,7 @@
     },
     {
         "id": "cc7",
-        "colour": "#f6cf44",
+        "colour": "#ab5797",
         "fg": "#fff",
         "name": {
             "en": "Line 7",
@@ -81,7 +81,7 @@
     },
     {
         "id": "cc9",
-        "colour": "#a26745",
+        "colour": "#2e79ba",
         "fg": "#fff",
         "name": {
             "en": "Line 9",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Changchun on behalf of Xiaoshuabc.
This should fix #1051

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#e50012`, fg=`#fff`
Line 2: bg=`#1a4695`, fg=`#fff`
Line 3: bg=`#009844`, fg=`#fff`
Line 4: bg=`#684184`, fg=`#fff`
Line 5: bg=`#a88546`, fg=`#fff`
Line 6: bg=`#e48aa4`, fg=`#fff`
Line 7: bg=`#ab5797`, fg=`#fff`
Line 8: bg=`#4bb4b8`, fg=`#fff`
Line 9: bg=`#2e79ba`, fg=`#fff`