### PR TITLE
Resources: New palettes of Hong Kong

### DIFF
--- a/public/resources/palettes/hongkong.json
+++ b/public/resources/palettes/hongkong.json
@@ -1,17 +1,7 @@
 [
     {
-        "id": "twl",
-        "colour": "#E2231A",
-        "fg": "#fff",
-        "name": {
-            "en": "Tsuen Wan Line",
-            "zh-Hans": "荃湾线",
-            "zh-Hant": "荃灣綫"
-        }
-    },
-    {
         "id": "ktl",
-        "colour": "#00AF41",
+        "colour": "#149331",
         "fg": "#fff",
         "name": {
             "en": "Kwun Tong Line",
@@ -20,8 +10,18 @@
         }
     },
     {
+        "id": "twl",
+        "colour": "#dd0011",
+        "fg": "#fff",
+        "name": {
+            "en": "Tsuen Wan Line",
+            "zh-Hans": "荃湾线",
+            "zh-Hant": "荃灣綫"
+        }
+    },
+    {
         "id": "isl",
-        "colour": "#0071CE",
+        "colour": "#0c5fb4",
         "fg": "#fff",
         "name": {
             "en": "Island Line",
@@ -31,7 +31,7 @@
     },
     {
         "id": "tkl",
-        "colour": "#A35EB5",
+        "colour": "#6a2780",
         "fg": "#fff",
         "name": {
             "en": "Tseung Kwan O Line",
@@ -41,7 +41,7 @@
     },
     {
         "id": "tcl",
-        "colour": "#F38B00",
+        "colour": "#ee8523",
         "fg": "#fff",
         "name": {
             "en": "Tung Chung Line",
@@ -50,58 +50,18 @@
         }
     },
     {
-        "id": "drl",
-        "colour": "#E777CB",
-        "fg": "#fff",
-        "name": {
-            "en": "Disney Resort Line",
-            "zh-Hans": "迪士尼线",
-            "zh-Hant": "迪士尼綫"
-        }
-    },
-    {
         "id": "ael",
-        "colour": "#007078",
+        "colour": "#0f767b",
         "fg": "#fff",
         "name": {
             "en": "Airport Express",
-            "zh-Hans": "机场快线",
-            "zh-Hant": "機場快綫"
+            "zh-Hans": "机场快线 (机铁)",
+            "zh-Hant": "機場快綫 (機鐵)"
         }
     },
     {
-        "id": "sile",
-        "colour": "#B6BD00",
-        "fg": "#fff",
-        "name": {
-            "en": "South Island Line (East)",
-            "zh-Hans": "南港岛线（东段）",
-            "zh-Hant": "南港島綫（東段）"
-        }
-    },
-    {
-        "id": "silw",
-        "colour": "#9182C2",
-        "fg": "#fff",
-        "name": {
-            "en": "South Island Line (West)",
-            "zh-Hans": "南港岛线（西段）",
-            "zh-Hant": "南港島綫（西段）"
-        }
-    },
-    {
-        "id": "ekl",
-        "colour": "#006633",
-        "fg": "#fff",
-        "name": {
-            "en": "East Kowloon Line",
-            "zh-Hans": "东九龙线",
-            "zh-Hant": "東九龍綫"
-        }
-    },
-    {
-        "id": "eal",
-        "colour": "#61B4E4",
+        "id": "erl",
+        "colour": "#4ea8e2",
         "fg": "#fff",
         "name": {
             "en": "East Rail Line",
@@ -110,8 +70,8 @@
         }
     },
     {
-        "id": "mol",
-        "colour": "#9A3820",
+        "id": "tml",
+        "colour": "#891e02",
         "fg": "#fff",
         "name": {
             "en": "Tuen Ma Line",
@@ -120,223 +80,23 @@
         }
     },
     {
-        "id": "nol",
-        "colour": "#a1208a",
+        "id": "drl",
+        "colour": "#e35494",
         "fg": "#fff",
         "name": {
-            "en": "Northern Link",
-            "zh-Hans": "北环线",
-            "zh-Hant": "北環綫"
+            "en": "Disneyland Resort Line",
+            "zh-Hans": "迪士尼线",
+            "zh-Hant": "迪士尼綫"
         }
     },
     {
-        "id": "lrl",
-        "colour": "#CD9700",
+        "id": "sil",
+        "colour": "#bfcd09",
         "fg": "#fff",
         "name": {
-            "en": "Light Rail",
-            "zh-Hans": "轻铁",
-            "zh-Hant": "輕鐵"
-        }
-    },
-    {
-        "id": "lrl505",
-        "colour": "#DB1F26",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 505",
-            "zh-Hans": "轻铁505线",
-            "zh-Hant": "輕鐵505綫"
-        }
-    },
-    {
-        "id": "lrl507",
-        "colour": "#00A650",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 507",
-            "zh-Hans": "轻铁507线",
-            "zh-Hant": "輕鐵507綫"
-        }
-    },
-    {
-        "id": "lrl610",
-        "colour": "#431115",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 610",
-            "zh-Hans": "轻铁610线",
-            "zh-Hant": "輕鐵610綫"
-        }
-    },
-    {
-        "id": "lrl614",
-        "colour": "#4DC6F4",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 614",
-            "zh-Hans": "轻铁614线",
-            "zh-Hant": "輕鐵614綫"
-        }
-    },
-    {
-        "id": "lrl614p",
-        "colour": "#F46989",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 614P",
-            "zh-Hans": "轻铁614P线",
-            "zh-Hant": "輕鐵614P綫"
-        }
-    },
-    {
-        "id": "lrl615",
-        "colour": "#FDDD04",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 615",
-            "zh-Hans": "轻铁615线",
-            "zh-Hant": "輕鐵615綫"
-        }
-    },
-    {
-        "id": "lrl615p",
-        "colour": "#215483",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 615P",
-            "zh-Hans": "轻铁615P线",
-            "zh-Hant": "輕鐵615P綫"
-        }
-    },
-    {
-        "id": "lrl705",
-        "colour": "#64C542",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 705",
-            "zh-Hans": "轻铁705线",
-            "zh-Hant": "輕鐵705綫"
-        }
-    },
-    {
-        "id": "lrl706",
-        "colour": "#B365B9",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 706",
-            "zh-Hans": "轻铁706线",
-            "zh-Hant": "輕鐵706綫"
-        }
-    },
-    {
-        "id": "lrl751",
-        "colour": "#F47216",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 751",
-            "zh-Hans": "轻铁751线",
-            "zh-Hant": "輕鐵751綫"
-        }
-    },
-    {
-        "id": "lrl761",
-        "colour": "#672290",
-        "fg": "#fff",
-        "name": {
-            "en": "Light Rail Route 761/761P",
-            "zh-Hans": "轻铁761/761P线",
-            "zh-Hant": "輕鐵761/761P綫"
-        }
-    },
-    {
-        "id": "efls",
-        "colour": "#000000",
-        "fg": "#fff",
-        "name": {
-            "en": "Environmentally Friendly Linkage System",
-            "zh-Hans": "环保连接系统",
-            "zh-Hant": "環保連接系統"
-        }
-    },
-    {
-        "id": "hsr",
-        "colour": "#9D968D",
-        "fg": "#fff",
-        "name": {
-            "en": "High Speed Rail",
-            "zh-Hans": "高速铁路",
-            "zh-Hant": "高速鐵路"
-        }
-    },
-    {
-        "id": "np360",
-        "colour": "#94989A",
-        "fg": "#fff",
-        "name": {
-            "en": "Ngong Ping 360",
-            "zh-Hans": "昂坪360",
-            "zh-Hant": "昂坪360"
-        }
-    },
-    {
-        "id": "tramways",
-        "colour": "#007549",
-        "fg": "#fff",
-        "name": {
-            "en": "Hong Kong Tramways",
-            "zh-Hans": "香港电车",
-            "zh-Hant": "香港電車"
-        }
-    },
-    {
-        "id": "ealkcr",
-        "colour": "#005DA0",
-        "fg": "#fff",
-        "name": {
-            "en": "KCR East Rail",
-            "zh-Hans": "九广东铁",
-            "zh-Hant": "九廣東鐵"
-        }
-    },
-    {
-        "id": "wrlkcr",
-        "colour": "#AC2571",
-        "fg": "#fff",
-        "name": {
-            "en": "KCR West Rail",
-            "zh-Hans": "九广西铁",
-            "zh-Hant": "九廣西鐵"
-        }
-    },
-    {
-        "id": "molkcr",
-        "colour": "#761E10",
-        "fg": "#fff",
-        "name": {
-            "en": "Ma On Shan Rail",
-            "zh-Hans": "九广马铁",
-            "zh-Hant": "九廣馬鐵"
-        }
-    },
-    {
-        "id": "lrlkcr",
-        "colour": "#FD722D",
-        "fg": "#fff",
-        "name": {
-            "en": "KCR Light Rail",
-            "zh-Hans": "九广轻铁",
-            "zh-Hant": "九廣輕鐵"
-        }
-    },
-    {
-        "id": "wrl",
-        "colour": "#B6008D",
-        "fg": "#fff",
-        "name": {
-            "en": "West Rail Line",
-            "zh-Hans": "西铁线",
-            "zh-Hant": "西鐵綫"
+            "en": "South Island Line",
+            "zh-Hans": "南港岛线",
+            "zh-Hant": "南港島綫"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Hong Kong on behalf of pokOSlanx.
This should fix #1056

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Kwun Tong Line: bg=`#149331`, fg=`#fff`
Tsuen Wan Line: bg=`#dd0011`, fg=`#fff`
Island Line: bg=`#0c5fb4`, fg=`#fff`
Tseung Kwan O Line: bg=`#6a2780`, fg=`#fff`
Tung Chung Line: bg=`#ee8523`, fg=`#fff`
Airport Express: bg=`#0f767b`, fg=`#fff`
East Rail Line: bg=`#4ea8e2`, fg=`#fff`
Tuen Ma Line: bg=`#891e02`, fg=`#fff`
Disneyland Resort Line: bg=`#e35494`, fg=`#fff`
South Island Line: bg=`#bfcd09`, fg=`#fff`