### PR TITLE
资源：鸭子的新调色板

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -415,6 +415,15 @@
         }
     },
     {
+        "id": "duck",
+        "country": "duckingcraft",
+        "name": {
+            "en": "duck",
+            "zh-Hans": "鸭子市",
+            "zh-Hant": "鸭子市"
+        }
+    },
+    {
         "id": "edinburgh",
         "country": "GBSCT",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -129,6 +129,15 @@
         "language": "da"
     },
     {
+        "id": "duckingcraft",
+        "name": {
+            "en": "Duckingcraft",
+            "zh-Hans": "鸭子市",
+            "zh-Hant": "鸭子市"
+        },
+        "language": "zh-Hans"
+    },
+    {
         "id": "EG",
         "name": {
             "en": "Egypt",

--- a/public/resources/palettes/duck.json
+++ b/public/resources/palettes/duck.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "duck1",
+        "colour": "#ff2600",
+        "fg": "#fff",
+        "name": {
+            "en": "line 1",
+            "zh-Hans": "1号线",
+            "zh-Hant": "鸭子市"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating 资源：鸭子的新调色板 on behalf of RyanZhangZ.
This should fix #1058

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

line 1: bg=`#ff2600`, fg=`#fff`