### PR TITLE
Resources: New palettes of Shanghai

### DIFF
--- a/public/resources/palettes/shanghai.json
+++ b/public/resources/palettes/shanghai.json
@@ -181,7 +181,7 @@
     },
     {
         "id": "sh19",
-        "colour": "#48864D",
+        "colour": "#40924F",
         "fg": "#fff",
         "name": {
             "en": "Line 19",
@@ -191,7 +191,7 @@
     },
     {
         "id": "sh20",
-        "colour": "#365299",
+        "colour": "#435B9E",
         "fg": "#fff",
         "name": {
             "en": "Line 20",
@@ -201,7 +201,7 @@
     },
     {
         "id": "sh21",
-        "colour": "#D6C66C",
+        "colour": "#D6C677",
         "fg": "#000",
         "name": {
             "en": "Line 21",
@@ -211,7 +211,7 @@
     },
     {
         "id": "sh23",
-        "colour": "#E0815E",
+        "colour": "#E98D60",
         "fg": "#000",
         "name": {
             "en": "Line 23",
@@ -227,6 +227,36 @@
             "en": "Pujiang Line",
             "zh-Hans": "浦江线",
             "zh-Hant": "浦江線"
+        }
+    },
+    {
+        "id": "chongming",
+        "colour": "#6BB392",
+        "fg": "#000",
+        "name": {
+            "en": "Chongming Line",
+            "zh-Hans": "崇明线",
+            "zh-Hant": "崇明線"
+        }
+    },
+    {
+        "id": "jsr",
+        "colour": "#000000",
+        "fg": "#fff",
+        "name": {
+            "zh-Hans": "金山铁路",
+            "en": "Jinshan Railway",
+            "zh-Hant": "金山鐵路"
+        }
+    },
+    {
+        "id": "maglev",
+        "colour": "#009090",
+        "fg": "#fff",
+        "name": {
+            "en": "Shanghai Maglev Train",
+            "zh-Hans": "磁浮线",
+            "zh-Hant": "磁浮線"
         }
     },
     {
@@ -290,38 +320,18 @@
         }
     },
     {
-        "id": "maglev",
-        "colour": "#009090",
-        "fg": "#fff",
-        "name": {
-            "en": "Shanghai Maglev Train",
-            "zh-Hans": "磁浮线",
-            "zh-Hant": "磁浮線"
-        }
-    },
-    {
-        "id": "jsr",
-        "colour": "#000000",
-        "fg": "#fff",
-        "name": {
-            "zh-Hans": "金山铁路",
-            "en": "Jinshan Railway",
-            "zh-Hant": "金山鐵路"
-        }
-    },
-    {
         "id": "airport",
-        "colour": "#266883",
+        "colour": "#3D6B8A",
         "fg": "#fff",
         "name": {
-            "en": "Airport Link Line",
+            "en": "Airport Connection Line",
             "zh-Hans": "机场联络线",
             "zh-Hant": "機場聯絡線"
         }
     },
     {
         "id": "jiamin",
-        "colour": "#734254",
+        "colour": "#724A57",
         "fg": "#fff",
         "name": {
             "en": "Jiamin Line",
@@ -330,23 +340,33 @@
         }
     },
     {
-        "id": "chongming",
-        "colour": "#6BB392",
-        "fg": "#000",
-        "name": {
-            "en": "Chongming Line",
-            "zh-Hans": "崇明线",
-            "zh-Hant": "崇明線"
-        }
-    },
-    {
         "id": "nanhui",
         "colour": "#93ABBB",
-        "fg": "#fff",
+        "fg": "#000",
         "name": {
             "en": "Nanhui Branch Line",
             "zh-Hans": "南汇支线",
             "zh-Hant": "南匯支線"
+        }
+    },
+    {
+        "id": "shifanqu",
+        "colour": "#6FB16B",
+        "fg": "#000",
+        "name": {
+            "en": "Shifanqu Line",
+            "zh-Hans": "示范区线",
+            "zh-Hant": "示範區線"
+        }
+    },
+    {
+        "id": "nanfeng",
+        "colour": "#4C6DA9",
+        "fg": "#fff",
+        "name": {
+            "en": "Nanfeng Line",
+            "zh-Hans": "南枫线",
+            "zh-Hant": "南楓線"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shanghai on behalf of 203IhzElttil.
This should fix #1060

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#E3002B`, fg=`#fff`
Line 2: bg=`#82BF25`, fg=`#000`
Line 3: bg=`#FCD600`, fg=`#000`
Line 4: bg=`#461D84`, fg=`#fff`
Line 5: bg=`#944D9A`, fg=`#fff`
Line 6: bg=`#D40068`, fg=`#fff`
Line 7: bg=`#ED6F00`, fg=`#000`
Line 8: bg=`#0094D8`, fg=`#fff`
Line 9: bg=`#87CAED`, fg=`#000`
Line 10: bg=`#C6AFD4`, fg=`#000`
Line 11: bg=`#871C2B`, fg=`#fff`
Line 12: bg=`#007A60`, fg=`#fff`
Line 13: bg=`#E999C0`, fg=`#000`
Line 14: bg=`#626020`, fg=`#fff`
Line 15: bg=`#BCA886`, fg=`#000`
Line 16: bg=`#98D1C0`, fg=`#000`
Line 17: bg=`#BC796F`, fg=`#fff`
Line 18: bg=`#C4984F`, fg=`#000`
Line 19: bg=`#40924F`, fg=`#fff`
Line 20: bg=`#435B9E`, fg=`#fff`
Line 21: bg=`#D6C677`, fg=`#000`
Line 23: bg=`#E98D60`, fg=`#000`
Pujiang Line: bg=`#B5B5B6`, fg=`#fff`
Chongming Line: bg=`#6BB392`, fg=`#000`
Jinshan Railway: bg=`#000000`, fg=`#fff`
Shanghai Maglev Train: bg=`#009090`, fg=`#fff`
Songjiang Tram T1: bg=`#FF0000`, fg=`#fff`
Songjiang Tram T2: bg=`#46837B`, fg=`#fff`
Songjiang Tram T3: bg=`#009400`, fg=`#fff`
Songjiang Tram T4: bg=`#FF00FF`, fg=`#fff`
Songjiang Tram T5: bg=`#00FD00`, fg=`#fff`
Songjiang Tram T6: bg=`#6E00DD`, fg=`#fff`
Airport Connection Line: bg=`#3D6B8A`, fg=`#fff`
Jiamin Line: bg=`#724A57`, fg=`#fff`
Nanhui Branch Line: bg=`#93ABBB`, fg=`#000`
Shifanqu Line: bg=`#6FB16B`, fg=`#000`
Nanfeng Line: bg=`#4C6DA9`, fg=`#fff`