### PR TITLE
Resources: New palettes of Tianjin

### DIFF
--- a/public/resources/palettes/tianjin.json
+++ b/public/resources/palettes/tianjin.json
@@ -25,7 +25,6 @@
         "id": "tj3",
         "colour": "#0081A6",
         "fg": "#fff",
-        "pantone": "2391 C",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
@@ -47,7 +46,6 @@
         "id": "tj5",
         "colour": "#E35205",
         "fg": "#fff",
-        "pantone": "166 C",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",

--- a/public/resources/palettes/tianjin.json
+++ b/public/resources/palettes/tianjin.json
@@ -25,6 +25,7 @@
         "id": "tj3",
         "colour": "#0081A6",
         "fg": "#fff",
+        "pantone": "2391 C",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
@@ -46,6 +47,7 @@
         "id": "tj5",
         "colour": "#E35205",
         "fg": "#fff",
+        "pantone": "166 C",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
@@ -138,6 +140,28 @@
             "en": "Line 13",
             "zh-Hans": "13号线",
             "zh-Hant": "13號線"
+        }
+    },
+    {
+        "id": "tj14",
+        "colour": "#99D6EA",
+        "fg": "#fff",
+        "pantone": "2975 C",
+        "name": {
+            "en": "Line 14",
+            "zh-Hans": "14号线",
+            "zh-Hant": "14號線"
+        }
+    },
+    {
+        "id": "tj15",
+        "colour": "#6ECEB2",
+        "fg": "#fff",
+        "pantone": "338 C",
+        "name": {
+            "en": "Line 15",
+            "zh-Hans": "15号线",
+            "zh-Hant": "15號線"
         }
     },
     {
@@ -307,28 +331,6 @@
             "en": "TEDA Modern Guided Rail Tram",
             "zh-Hans": "导轨1号线",
             "zh-Hant": "導軌1號線"
-        }
-    },
-    {
-        "id": "tj14",
-        "colour": "#99D6EA",
-        "fg": "#fff",
-        "pantone": "2975 C",
-        "name": {
-            "en": "Line 14",
-            "zh-Hans": "14号线",
-            "zh-Hant": "14號線"
-        }
-    },
-    {
-        "id": "tj15",
-        "colour": "#6ECEB2",
-        "fg": "#fff",
-        "pantone": "338 C",
-        "name": {
-            "en": "Line 15",
-            "zh-Hans": "15号线",
-            "zh-Hant": "15號線"
         }
     },
     {


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Tianjin on behalf of HatsuneMikuZD.
This should fix #1065

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#CB333B`, fg=`#fff`
Line 2: bg=`#E1E000`, fg=`#000`
Line 3: bg=`#0081A6`, fg=`#fff`
Line 4: bg=`#007A33`, fg=`#fff`
Line 5: bg=`#E35205`, fg=`#fff`
Line 6: bg=`#994878`, fg=`#fff`
Line 7: bg=`#C6893F`, fg=`#fff`
Line 8: bg=`#84329B`, fg=`#fff`
Line 9: bg=`#0047BB`, fg=`#fff`
Line 10: bg=`#C4D600`, fg=`#fff`
Line 11: bg=`#002D72`, fg=`#fff`
Line 12: bg=`#F99FC9`, fg=`#fff`
Line 13: bg=`#FFC845`, fg=`#000`
Line 14: bg=`#99D6EA`, fg=`#fff`
Line 15: bg=`#6ECEB2`, fg=`#fff`
Line B1: bg=`#E03E52`, fg=`#fff`
Line B2: bg=`#F3EA5D`, fg=`#fff`
Line B3: bg=`#2CCCD3`, fg=`#fff`
Line B4: bg=`#6CC24A`, fg=`#fff`
Line B5: bg=`#FEAD77`, fg=`#fff`
Line B6: bg=`#B06C95`, fg=`#fff`
Line B7: bg=`#B9975B`, fg=`#fff`
Line C1: bg=`#d1ce69`, fg=`#fff`
Line C2: bg=`#dd8dae`, fg=`#fff`
Line C3: bg=`#769c62`, fg=`#fff`
Line C4: bg=`#5c480f`, fg=`#fff`
Line Z1: bg=`#626da7`, fg=`#fff`
Line Z2: bg=`#006BA6`, fg=`#fff`
Line Z3: bg=`#bd5832`, fg=`#fff`
Line Z4: bg=`#A57FB2`, fg=`#fff`
TEDA Modern Guided Rail Tram: bg=`#8FC31F`, fg=`#fff`
Jinjing Line: bg=`#F8B5C4`, fg=`#fff`
Jinwu Line: bg=`#FFC72C`, fg=`#fff`
Jinning Line: bg=`#DECD63`, fg=`#fff`
Jinbin Line: bg=`#8B84D7`, fg=`#fff`
Jingang Line: bg=`#4A412A`, fg=`#fff`
Ningwu Connection Line: bg=`#FDAA63`, fg=`#fff`
Shuanghu Connection Line: bg=`#C66E4E`, fg=`#fff`