### PR TITLE
Resources: New palettes of Nanjing

### DIFF
--- a/public/resources/palettes/nanjing.json
+++ b/public/resources/palettes/nanjing.json
@@ -11,7 +11,7 @@
     },
     {
         "id": "nj2",
-        "colour": "#c8003f",
+        "colour": "#a6093d",
         "fg": "#fff",
         "name": {
             "en": "Line 2",
@@ -41,7 +41,7 @@
     },
     {
         "id": "nj5",
-        "colour": "#FDDA24",
+        "colour": "#f2da51",
         "fg": "#fff",
         "name": {
             "en": "Line 5",
@@ -51,7 +51,7 @@
     },
     {
         "id": "nj6",
-        "colour": "#00b2a9",
+        "colour": "#4bbbb4",
         "fg": "#fff",
         "name": {
             "en": "Line 6",
@@ -101,7 +101,7 @@
     },
     {
         "id": "s1",
-        "colour": "#00b2a9",
+        "colour": "#4bbbb4",
         "fg": "#fff",
         "name": {
             "en": "Line S1/Airport Line",
@@ -111,7 +111,7 @@
     },
     {
         "id": "s3",
-        "colour": "#b06096",
+        "colour": "#ba84ac",
         "fg": "#fff",
         "name": {
             "en": "Line S3/Ninghe Line",
@@ -141,7 +141,7 @@
     },
     {
         "id": "s7",
-        "colour": "#e89cae",
+        "colour": "#b46b7a",
         "fg": "#fff",
         "name": {
             "en": "Line S7/Ningli Line",
@@ -151,7 +151,7 @@
     },
     {
         "id": "s8",
-        "colour": "#ea7600",
+        "colour": "#ff8000",
         "fg": "#fff",
         "name": {
             "en": "Line S8/Ningtian Line",
@@ -161,7 +161,7 @@
     },
     {
         "id": "s9",
-        "colour": "#f1b434",
+        "colour": "#ffc600",
         "fg": "#fff",
         "name": {
             "en": "Line S9/Ninggao Line",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanjing on behalf of xdedm2005.
This should fix #1069

> @railmapgen/rmg-palette-resources@2.2.2 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#009ace`, fg=`#fff`
Line 2: bg=`#a6093d`, fg=`#fff`
Line 3: bg=`#009a44`, fg=`#fff`
Line 4: bg=`#7d55c7`, fg=`#fff`
Line 5: bg=`#f2da51`, fg=`#fff`
Line 6: bg=`#4bbbb4`, fg=`#fff`
Line 7: bg=`#4A7729`, fg=`#fff`
Line 9: bg=`#fa4616`, fg=`#fff`
Line 10: bg=`#b9975b`, fg=`#fff`
Line 11: bg=`#ef426f`, fg=`#fff`
Line S1/Airport Line: bg=`#4bbbb4`, fg=`#fff`
Line S3/Ninghe Line: bg=`#ba84ac`, fg=`#fff`
Line S4/Ningchu Line: bg=`#ff6314`, fg=`#fff`
Line S6/Ningju Line: bg=`#C98BDB`, fg=`#fff`
Line S7/Ningli Line: bg=`#b46b7a`, fg=`#fff`
Line S8/Ningtian Line: bg=`#ff8000`, fg=`#fff`
Line S9/Ninggao Line: bg=`#ffc600`, fg=`#fff`