### PR TITLE
Resources: New palettes of Seoul (Metropolitan Area)

### DIFF
--- a/public/resources/palettes/seoul.json
+++ b/public/resources/palettes/seoul.json
@@ -1,202 +1,255 @@
 [
     {
         "id": "su1",
-        "colour": "#0d3692",
+        "colour": "#0052a4",
         "fg": "#fff",
         "name": {
             "en": "Line 1",
             "ko": "1호선",
-            "zh-Hans": "1号线"
+            "zh-Hans": "1号线",
+            "zh-Hant": "1號線"
         }
     },
     {
         "id": "su2",
-        "colour": "#33a23d",
+        "colour": "#00a84d",
         "fg": "#fff",
         "name": {
             "en": "Line 2",
             "ko": "2호선",
-            "zh-Hans": "2号线"
+            "zh-Hans": "2号线",
+            "zh-Hant": "2號線"
         }
     },
     {
         "id": "su3",
-        "colour": "#fe5b10",
+        "colour": "#ef7c1c",
         "fg": "#fff",
         "name": {
             "en": "Line 3",
             "ko": "3호선",
-            "zh-Hans": "3号线"
+            "zh-Hans": "3号线",
+            "zh-Hant": "3號線"
         }
     },
     {
         "id": "su4",
-        "colour": "#32a1c8",
+        "colour": "#00a4e3",
         "fg": "#fff",
         "name": {
             "en": "Line 4",
             "ko": "4호선",
-            "zh-Hans": "4号线"
+            "zh-Hans": "4号线",
+            "zh-Hant": "4號線"
         }
     },
     {
         "id": "su5",
-        "colour": "#8b50a4",
+        "colour": "#996cac",
         "fg": "#fff",
         "name": {
             "en": "Line 5",
             "ko": "5호선",
-            "zh-Hans": "5号线"
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號線"
         }
     },
     {
         "id": "su6",
-        "colour": "#c55c1d",
+        "colour": "#cd7c2f",
         "fg": "#fff",
         "name": {
             "en": "Line 6",
             "ko": "6호선",
-            "zh-Hans": "6号线"
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號線"
         }
     },
     {
         "id": "su7",
-        "colour": "#54640d",
+        "colour": "#747f00",
         "fg": "#fff",
         "name": {
             "en": "Line 7",
             "ko": "7호선",
-            "zh-Hans": "7号线"
+            "zh-Hans": "7号线",
+            "zh-Hant": "7號線"
         }
     },
     {
         "id": "su8",
-        "colour": "#f51361",
+        "colour": "#e6186c",
         "fg": "#fff",
         "name": {
             "en": "Line 8",
             "ko": "8호선",
-            "zh-Hans": "8号线"
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號線"
         }
     },
     {
         "id": "su9",
-        "colour": "#aa9872",
+        "colour": "#bdb092",
         "fg": "#fff",
         "name": {
             "en": "Line 9",
             "ko": "9호선",
-            "zh-Hans": "9号线"
-        }
-    },
-    {
-        "id": "arx",
-        "colour": "#3681b7",
-        "fg": "#fff",
-        "name": {
-            "en": "Airport Railroad Express",
-            "ko": "인천국제공항철도",
-            "zh-Hans": "仁川国际机场铁道"
-        }
-    },
-    {
-        "id": "gj",
-        "colour": "#72c7a6",
-        "fg": "#fff",
-        "name": {
-            "en": "Gyeongui–Jungang Line",
-            "ko": "경의·중앙선",
-            "zh-Hans": "京义·中央线"
-        }
-    },
-    {
-        "id": "bun",
-        "colour": "#F5A200",
-        "fg": "#000",
-        "name": {
-            "en": "Suin–Bundang Line",
-            "ko": "수인·분당선",
-            "zh-Hans": "水仁·盆唐线"
+            "zh-Hans": "9号线",
+            "zh-Hant": "9號線"
         }
     },
     {
         "id": "gg",
-        "colour": "#004fa2",
+        "colour": "#0054a6",
         "fg": "#fff",
         "name": {
             "en": "Gyeonggang Line",
             "ko": "경강선",
-            "zh-Hans": "京江线"
+            "zh-Hans": "京江线",
+            "zh-Hant": "京江線"
+        }
+    },
+    {
+        "id": "gj",
+        "colour": "#77c4a3",
+        "fg": "#fff",
+        "name": {
+            "en": "Gyeongui–Jungang Line",
+            "ko": "경의·중앙선",
+            "zh-Hans": "京义·中央线",
+            "zh-Hant": "京義·中央線"
         }
     },
     {
         "id": "gc",
-        "colour": "#0C8E72",
+        "colour": "#178c72",
         "fg": "#fff",
         "name": {
             "en": "Gyeongchun Line",
             "ko": "경춘선",
-            "zh-Hans": "京春线"
+            "zh-Hans": "京春线",
+            "zh-Hant": "京春線"
         }
     },
     {
-        "id": "ui",
-        "colour": "#b7c452",
+        "id": "a",
+        "colour": "#0090d2",
         "fg": "#fff",
         "name": {
-            "en": "Ui LRT",
-            "ko": "우이신설선",
-            "zh-Hans": "牛耳新设线"
+            "en": "Airport Railroad Express",
+            "ko": "인천국제공항철도",
+            "zh-Hans": "仁川国际机场铁道",
+            "zh-Hant": "仁川國際空港鐵道"
         }
     },
     {
-        "id": "sin",
-        "colour": "#D4003B",
-        "fg": "#fff",
-        "name": {
-            "en": "Shinbundang Line",
-            "ko": "신분당선",
-            "zh-Hans": "新盆唐线"
-        }
-    },
-    {
-        "id": "seo",
-        "colour": "#81A914",
+        "id": "s",
+        "colour": "#8fc31f",
         "fg": "#fff",
         "name": {
             "en": "Seohae Line",
             "ko": "서해선",
-            "zh-Hans": "西海线"
+            "zh-Hans": "西海线",
+            "zh-Hant": "西海線"
         }
     },
     {
-        "id": "i1",
-        "colour": "#6e98bb",
+        "id": "sb",
+        "colour": "#fabe00",
+        "fg": "#000",
+        "name": {
+            "en": "Suin–Bundang Line",
+            "ko": "수인·분당선",
+            "zh-Hans": "水仁·盆唐线",
+            "zh-Hant": "水仁·盆唐線"
+        }
+    },
+    {
+        "id": "d",
+        "colour": "#d31145",
         "fg": "#fff",
         "name": {
-            "en": "Incheon Subway Line 1",
-            "ko": "인천 1호선",
-            "zh-Hans": "仁川1号线"
+            "en": "Shinbundang Line",
+            "ko": "신분당선",
+            "zh-Hans": "新盆唐线",
+            "zh-Hant": "新盆唐線"
         }
     },
     {
-        "id": "i2",
-        "colour": "#ED8B00",
+        "id": "g",
+        "colour": "#ad8605",
         "fg": "#fff",
         "name": {
-            "en": "Incheon Subway Line 2",
-            "ko": "인천 2호선",
-            "zh-Hans": "仁川2号线"
+            "en": "Gimpo Goldline",
+            "ko": "김포도시철도",
+            "zh-Hans": "金浦都市铁道",
+            "zh-Hant": "金浦都市鐵道"
         }
     },
     {
-        "id": "uij",
-        "colour": "#fda600",
+        "id": "si",
+        "colour": "#6789ca",
+        "fg": "#fff",
+        "name": {
+            "en": "Sillim Line",
+            "ko": "신림선",
+            "zh-Hans": "新林线",
+            "zh-Hant": "新林線"
+        }
+    },
+    {
+        "id": "y",
+        "colour": "#509F22",
+        "fg": "#fff",
+        "name": {
+            "en": "Yongin Everline",
+            "ko": "에버라인",
+            "zh-Hans": "龙仁轻电铁",
+            "zh-Hant": "龍仁輕電鐵"
+        }
+    },
+    {
+        "id": "ui",
+        "colour": "#b7c450",
+        "fg": "#fff",
+        "name": {
+            "en": "Ui-Sinseol Line",
+            "ko": "우이신설선",
+            "zh-Hans": "牛耳新设线",
+            "zh-Hant": "牛耳新設線"
+        }
+    },
+    {
+        "id": "u",
+        "colour": "#fd8100",
         "fg": "#fff",
         "name": {
             "en": "U Line",
             "ko": "의정부경전철",
-            "zh-Hans": "议政府轻电铁"
+            "zh-Hans": "议政府轻电铁",
+            "zh-Hant": "議政府輕電鐵"
+        }
+    },
+    {
+        "id": "i1",
+        "colour": "#759cce",
+        "fg": "#fff",
+        "name": {
+            "en": "Incheon Metro Line 1",
+            "ko": "인천1호선",
+            "zh-Hans": "仁川1号线",
+            "zh-Hant": "仁川1號線"
+        }
+    },
+    {
+        "id": "i2",
+        "colour": "#f5a251",
+        "fg": "#fff",
+        "name": {
+            "en": "Incheon Metro Line 2",
+            "ko": "인천2호선",
+            "zh-Hans": "仁川2号线",
+            "zh-Hant": "仁川2號線"
         }
     },
     {
@@ -204,39 +257,10 @@
         "colour": "#ffcd12",
         "fg": "#fff",
         "name": {
-            "en": "Incheon Airport Maglev",
-            "ko": "인천공항 자기부상철도",
-            "zh-Hans": "仁川机场磁悬浮线"
-        }
-    },
-    {
-        "id": "gim",
-        "colour": "#ad8605",
-        "fg": "#fff",
-        "name": {
-            "en": "Gimpo Goldline",
-            "ko": "김포 도시철도",
-            "zh-Hans": "金浦都市铁道"
-        }
-    },
-    {
-        "id": "ever",
-        "colour": "#509F22",
-        "fg": "#fff",
-        "name": {
-            "en": "EverLine",
-            "ko": "에버라인",
-            "zh-Hans": "龙仁轻电铁"
-        }
-    },
-    {
-        "id": "sillim",
-        "colour": "#6889ca",
-        "fg": "#fff",
-        "name": {
-            "en": "Sillim Line",
-            "ko": "신림선",
-            "zh-Hans": "新林线"
+            "en": "Incheon Airport Maglev Line",
+            "ko": "인천공항자기부상철도",
+            "zh-Hans": "仁川机场磁悬浮线",
+            "zh-Hant": "仁川空港磁氣浮上鐵道"
         }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Seoul (Metropolitan Area) on behalf of t-chai.
This should fix #1075

> @railmapgen/rmg-palette-resources@2.2.3 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#0052a4`, fg=`#fff`
Line 2: bg=`#00a84d`, fg=`#fff`
Line 3: bg=`#ef7c1c`, fg=`#fff`
Line 4: bg=`#00a4e3`, fg=`#fff`
Line 5: bg=`#996cac`, fg=`#fff`
Line 6: bg=`#cd7c2f`, fg=`#fff`
Line 7: bg=`#747f00`, fg=`#fff`
Line 8: bg=`#e6186c`, fg=`#fff`
Line 9: bg=`#bdb092`, fg=`#fff`
Gyeonggang Line: bg=`#0054a6`, fg=`#fff`
Gyeongui–Jungang Line: bg=`#77c4a3`, fg=`#fff`
Gyeongchun Line: bg=`#178c72`, fg=`#fff`
Airport Railroad Express: bg=`#0090d2`, fg=`#fff`
Seohae Line: bg=`#8fc31f`, fg=`#fff`
Suin–Bundang Line: bg=`#fabe00`, fg=`#000`
Shinbundang Line: bg=`#d31145`, fg=`#fff`
Gimpo Goldline: bg=`#ad8605`, fg=`#fff`
Sillim Line: bg=`#6789ca`, fg=`#fff`
Yongin Everline: bg=`#509F22`, fg=`#fff`
Ui-Sinseol Line: bg=`#b7c450`, fg=`#fff`
U Line: bg=`#fd8100`, fg=`#fff`
Incheon Metro Line 1: bg=`#759cce`, fg=`#fff`
Incheon Metro Line 2: bg=`#f5a251`, fg=`#fff`
Incheon Airport Maglev Line: bg=`#ffcd12`, fg=`#fff`