### PR TITLE
Resources: New palettes of Jinan

### DIFF
--- a/public/resources/palettes/jinan.json
+++ b/public/resources/palettes/jinan.json
@@ -1,38 +1,92 @@
 [
     {
         "id": "jn1",
+        "colour": "#BE1FA1",
+        "fg": "#fff",
         "name": {
             "en": "Line 1",
             "zh-Hans": "1号线",
             "zh-Hant": "1號線"
-        },
-        "colour": "#BE1FA1"
+        }
     },
     {
         "id": "jn2",
+        "colour": "#FFB620",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#FFB620"
+        }
     },
     {
         "id": "jn3",
+        "colour": "#0073CE",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#0073CE"
+        }
     },
     {
         "id": "jn4",
+        "colour": "#ca0106",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#229719"
+        }
+    },
+    {
+        "id": "jn5",
+        "colour": "#a0c3dc",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 5",
+            "zh-Hans": "5号线",
+            "zh-Hant": "5號線"
+        }
+    },
+    {
+        "id": "jn6",
+        "colour": "#02772f",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 6",
+            "zh-Hans": "6号线",
+            "zh-Hant": "6號線"
+        }
+    },
+    {
+        "id": "jn7",
+        "colour": "#f07a01",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 7",
+            "zh-Hans": "7号线",
+            "zh-Hant": "7號線"
+        }
+    },
+    {
+        "id": "jn8",
+        "colour": "#663100",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 8",
+            "zh-Hans": "8号线",
+            "zh-Hant": "8號線"
+        }
+    },
+    {
+        "id": "jn9",
+        "colour": "#970296",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 9",
+            "zh-Hans": "9号线",
+            "zh-Hant": "9號線"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Jinan on behalf of CSZ7943.
This should fix #1081

> @railmapgen/rmg-palette-resources@2.2.3 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#BE1FA1`, fg=`#fff`
Line 2: bg=`#FFB620`, fg=`#fff`
Line 3: bg=`#0073CE`, fg=`#fff`
Line 4: bg=`#ca0106`, fg=`#fff`
Line 5: bg=`#a0c3dc`, fg=`#fff`
Line 6: bg=`#02772f`, fg=`#fff`
Line 7: bg=`#f07a01`, fg=`#fff`
Line 8: bg=`#663100`, fg=`#fff`
Line 9: bg=`#970296`, fg=`#fff`