### PR TITLE
Resources: New palettes of Wuxi

### DIFF
--- a/public/resources/palettes/wuxi.json
+++ b/public/resources/palettes/wuxi.json
@@ -1,47 +1,52 @@
 [
     {
-        "id": "wx1",
+        "id": "wx1_s1",
+        "colour": "#EE2737",
+        "fg": "#fff",
         "name": {
-            "en": "Line 1",
-            "zh-Hans": "1号线",
-            "zh-Hant": "1號線"
-        },
-        "colour": "#EE2737"
+            "en": "Line 1-Line S1",
+            "zh-Hans": "1号线- S1线/锡澄线",
+            "zh-Hant": "1號線-S1線/錫澄線"
+        }
     },
     {
         "id": "wx2",
+        "colour": "#00B140",
+        "fg": "#fff",
         "name": {
             "en": "Line 2",
             "zh-Hans": "2号线",
             "zh-Hant": "2號線"
-        },
-        "colour": "#00B140"
+        }
     },
     {
         "id": "wx3",
+        "colour": "#00A9E0",
+        "fg": "#fff",
         "name": {
             "en": "Line 3",
             "zh-Hans": "3号线",
             "zh-Hant": "3號線"
-        },
-        "colour": "#00A9E0"
+        }
     },
     {
         "id": "wx4",
+        "colour": "#93328E",
+        "fg": "#fff",
         "name": {
             "en": "Line 4",
             "zh-Hans": "4号线",
             "zh-Hant": "4號線"
-        },
-        "colour": "#93328E"
+        }
     },
     {
         "id": "wx5",
+        "colour": "#FFB81C",
+        "fg": "#fff",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",
             "zh-Hant": "5號線"
-        },
-        "colour": "#FFB81C"
+        }
     }
 ]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Wuxi on behalf of MajorDucks.
This should fix #1089

> @railmapgen/rmg-palette-resources@2.2.3 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1-Line S1: bg=`#EE2737`, fg=`#fff`
Line 2: bg=`#00B140`, fg=`#fff`
Line 3: bg=`#00A9E0`, fg=`#fff`
Line 4: bg=`#93328E`, fg=`#fff`
Line 5: bg=`#FFB81C`, fg=`#fff`