### PR TITLE
Resources: New palettes of Shenzhen

### DIFF
--- a/public/resources/palettes/shenzhen.json
+++ b/public/resources/palettes/shenzhen.json
@@ -160,6 +160,16 @@
         }
     },
     {
+        "id": "sz17",
+        "colour": "#d3c0cd",
+        "fg": "#fff",
+        "name": {
+            "en": "Line 17",
+            "zh-Hans": "17号线",
+            "zh-Hant": "17號線"
+        }
+    },
+    {
         "id": "sz16",
         "colour": "#1E22AA",
         "fg": "#fff",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Shenzhen on behalf of CRT06003.
This should fix #1100

> @railmapgen/rmg-palette-resources@2.2.3 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1 (Luobao Line): bg=`#00B140`, fg=`#fff`
Line 2 (Shekou Line): bg=`#B94700`, fg=`#fff`
Line 3 (Longgang Line): bg=`#00A9E0`, fg=`#fff`
Line 4 (Longhua Line): bg=`#DA291C`, fg=`#fff`
Line 5 (Huanzhong Line): bg=`#A05EB5`, fg=`#fff`
Line 6（Guangming Line): bg=`#00C7B1`, fg=`#fff`
Line 6 branch: bg=`#168773`, fg=`#fff`
Line 7 (Xili Line): bg=`#0033A0`, fg=`#fff`
Line 8: bg=`#b94700`, fg=`#fff`
Line 9 (Meilin Line): bg=`#7B6469`, fg=`#fff`
Line 10 (Bantian Line): bg=`#F8779E`, fg=`#fff`
Line 11: bg=`#672146`, fg=`#fff`
Line 12 (Nanbao Line): bg=`#A192B2`, fg=`#fff`
Line 13 (Shiyan Line): bg=`#DE7C00`, fg=`#fff`
Line 14 (Eastern Express): bg=`#F2C75C`, fg=`#fff`
Line 15: bg=`#84BD00`, fg=`#fff`
Line 17: bg=`#d3c0cd`, fg=`#fff`
Line 16 (Longping Line): bg=`#1E22AA`, fg=`#fff`
Line 20: bg=`#88DBDF`, fg=`#fff`
Tram: bg=`#b8b8b8`, fg=`#fff`
Line 8 (Original): bg=`#E45DBF`, fg=`#fff`
Pingshan sky shuttlo: bg=`#1974d2`, fg=`#fff`