### PR TITLE
Resources: New palettes of Changchun

### DIFF
--- a/public/resources/palettes/changchun.json
+++ b/public/resources/palettes/changchun.json
@@ -51,7 +51,7 @@
     },
     {
         "id": "cc6",
-        "colour": "#df7413",
+        "colour": "#de949b",
         "fg": "#fff",
         "name": {
             "en": "Line 6",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Changchun on behalf of @28yfang.

This should fix #1172

> @railmapgen/rmg-palette-resources@2.2.4 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#e50012`, fg=`#fff`
Line 2: bg=`#1a4695`, fg=`#fff`
Line 3: bg=`#009844`, fg=`#fff`
Line 4: bg=`#684184`, fg=`#fff`
Line 5: bg=`#f8408a`, fg=`#fff`
Line 6: bg=`#de949b`, fg=`#fff`
Line 7: bg=`#f6cf44`, fg=`#fff`
Line 8: bg=`#4bb4b8`, fg=`#fff`
Line 9: bg=`#a26745`, fg=`#fff`
