### PR TITLE
#1180 Resources: New palettes of Nanjing

### DIFF
--- a/public/resources/palettes/nanjing.json
+++ b/public/resources/palettes/nanjing.json
@@ -42,7 +42,7 @@
     {
         "id": "nj5",
         "colour": "#f2da51",
-        "fg": "#fff",
+        "fg": "#000",
         "name": {
             "en": "Line 5",
             "zh-Hans": "5号线",


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Nanjing on behalf of Windows-Taskmgr.
This should fix #1180

> @railmapgen/rmg-palette-resources@2.2.4 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Line 1: bg=`#009ace`, fg=`#fff`
Line 2: bg=`#a6093d`, fg=`#fff`
Line 3: bg=`#009a44`, fg=`#fff`
Line 4: bg=`#7d55c7`, fg=`#fff`
Line 5: bg=`#f2da51`, fg=`#000`
Line 6: bg=`#4bbbb4`, fg=`#fff`
Line 7: bg=`#4A7729`, fg=`#fff`
Line 9: bg=`#fa4616`, fg=`#fff`
Line 10: bg=`#b9975b`, fg=`#fff`
Line 11: bg=`#ef426f`, fg=`#fff`
Line S1/Airport Line: bg=`#4bbbb4`, fg=`#fff`
Line S2/Ningma Line: bg=`#93282c`, fg=`#fff`
Line S3/Ninghe Line: bg=`#ba84ac`, fg=`#fff`
Line S4/Ningchu Line: bg=`#ff6314`, fg=`#fff`
Line S6/Ningju Line: bg=`#C98BDB`, fg=`#fff`
Line S7/Ningli Line: bg=`#b46b7a`, fg=`#fff`
Line S8/Ningtian Line: bg=`#ff8000`, fg=`#fff`
Line S9/Ninggao Line: bg=`#ffc600`, fg=`#fff`