### PR TITLE
#1163 Resources: New palettes of Tel Aviv-Yafo

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -1586,6 +1586,15 @@
         }
     },
     {
+        "id": "telivivyafo",
+        "country": "IL",
+        "name": {
+            "en": "Tel Aviv-Yafo",
+            "zh-Hans": "特拉维夫-雅法",
+            "zh-Hant": "特拉維夫-雅法"
+        }
+    },
+    {
         "id": "tianjin",
         "country": "CN",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -227,6 +227,15 @@
         "language": "ga"
     },
     {
+        "id": "IL",
+        "name": {
+            "en": "Israel",
+            "zh-Hans": "以色列",
+            "zh-Hant": "以色列"
+        },
+        "language": "en"
+    },
+    {
         "id": "IN",
         "name": {
             "en": "India",

--- a/public/resources/palettes/telivivyafo.json
+++ b/public/resources/palettes/telivivyafo.json
@@ -1,0 +1,62 @@
+[
+    {
+        "id": "rl",
+        "colour": "#ee1d23",
+        "fg": "#fff",
+        "name": {
+            "en": "Red line",
+            "zh-Hans": "红线",
+            "zh-Hant": "紅綫"
+        }
+    },
+    {
+        "id": "gl",
+        "colour": "#2daf52",
+        "fg": "#fff",
+        "name": {
+            "en": "Green Line",
+            "zh-Hans": "绿线",
+            "zh-Hant": "綠綫"
+        }
+    },
+    {
+        "id": "pl",
+        "colour": "#942685",
+        "fg": "#fff",
+        "name": {
+            "en": "Purple Line",
+            "zh-Hans": "紫线",
+            "zh-Hant": "紫綫"
+        }
+    },
+    {
+        "id": "m1",
+        "colour": "#0000fe",
+        "fg": "#fff",
+        "name": {
+            "en": "Line M1",
+            "zh-Hans": "M1线",
+            "zh-Hant": "M1綫"
+        }
+    },
+    {
+        "id": "m2",
+        "colour": "#ffa500",
+        "fg": "#fff",
+        "name": {
+            "en": "Line M2",
+            "zh-Hans": "M2线",
+            "zh-Hant": "M2綫"
+        }
+    },
+    {
+        "id": "m3",
+        "colour": "#ffd500",
+        "fg": "#fff",
+        "name": {
+            "en": "Line M3",
+            "zh-Hans": "M3线",
+            "zh-Hant": "M3綫"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Tel Aviv-Yafo on behalf of vicemoter0062.
This should fix #1163

> @railmapgen/rmg-palette-resources@2.2.4 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Red Line: bg=`#ee1d23`, fg=`#fff`
Green Line: bg=`#2daf52`, fg=`#fff`
Purple Line: bg=`#942685`, fg=`#fff`
Line M1: bg=`#0000fe`, fg=`#fff`
Line M2: bg=`#ffa500`, fg=`#fff`
Line M3: bg=`#ffd500`, fg=`#fff`