### PR TITLE
Resources: New palettes of Haifa

### DIFF
--- a/public/resources/city-config.json
+++ b/public/resources/city-config.json
@@ -553,6 +553,15 @@
         }
     },
     {
+        "id": "haifa",
+        "country": "IL",
+        "name": {
+            "en": "Haifa",
+            "zh-Hans": "海法",
+            "zh-Hant": "海法"
+        }
+    },
+    {
         "id": "hamburg",
         "country": "DE",
         "name": {

--- a/public/resources/country-config.json
+++ b/public/resources/country-config.json
@@ -227,6 +227,15 @@
         "language": "ga"
     },
     {
+        "id": "IL",
+        "name": {
+            "en": "Israel",
+            "zh-Hans": "以色列",
+            "zh-Hant": "以色列"
+        },
+        "language": "en"
+    },
+    {
         "id": "IN",
         "name": {
             "en": "India",

--- a/public/resources/palettes/haifa.json
+++ b/public/resources/palettes/haifa.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": "carmelit",
+        "colour": "#ea3808",
+        "fg": "#fff",
+        "name": {
+            "en": "Carmelit",
+            "zh-Hans": "海法地铁",
+            "zh-Hant": "海法地鐵"
+        }
+    }
+]


### PR DESCRIPTION
Hi, I'm the rmg bot updating Resources: New palettes of Haifa on behalf of vicemoter0062.
This should fix #1146

> @railmapgen/rmg-palette-resources@2.2.4 issuebot
> node --loader ts-node/esm issuebot/issuebot.mts

Printing all colours...

Carmelit: bg=`#ea3808`, fg=`#fff`